### PR TITLE
[ENG-8460] Add more data of decision to meta config on model

### DIFF
--- a/src/orchestra_dbt/logger.py
+++ b/src/orchestra_dbt/logger.py
@@ -38,6 +38,6 @@ def log_reused_nodes(nodes_to_reuse: dict[str, MaterialisationNode]) -> None:
     counter = 1
     for node_id, node in nodes_to_reuse.items():
         log_info(
-            f"{counter} of {total_nodes} REUSED {node_id} - {node.reason}. Last updated: {node.last_updated or 'none'}"
+            f"{counter} of {total_nodes} REUSED {node_id} - {node.reason} (last updated: {node.last_updated or 'none'})"
         )
         counter += 1

--- a/tests/integration/test_local.py
+++ b/tests/integration/test_local.py
@@ -2,9 +2,10 @@ import json
 from typing import cast
 from unittest.mock import patch
 
-from orchestra_dbt.logger import log_reused_nodes
-from orchestra_dbt.sao import calculate_nodes_to_run
+import pytest
+
 from src.orchestra_dbt.dag import construct_dag
+from src.orchestra_dbt.logger import log_reused_nodes
 from src.orchestra_dbt.models import (
     Freshness,
     MaterialisationNode,
@@ -12,13 +13,23 @@ from src.orchestra_dbt.models import (
     SourceFreshness,
     StateApiModel,
 )
+from src.orchestra_dbt.sao import calculate_nodes_to_run
 
 
 @patch("src.orchestra_dbt.dag.get_integration_account_id_from_env")
 def test_e2e(mock_get_integration_account_id_from_env):
+    try:
+        local_state = open("local_state.json", "r").read()
+    except FileNotFoundError:
+        pytest.skip("local_state.json not found")
+
+    try:
+        open("local_manifest.json", "r").read()
+    except FileNotFoundError:
+        pytest.skip("local_manifest.json not found")
+
     mock_get_integration_account_id_from_env.return_value = "TO_BE_COMPLETED"
 
-    local_state = open("local_state.json", "r").read()
     parsed_dag = construct_dag(
         source_freshness=SourceFreshness(sources={}),
         state=StateApiModel.model_validate(json.loads(local_state)),

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -40,6 +40,6 @@ class TestLogReusedNodes:
         log_lines = [line[26:-4] for line in log_lines]
         assert log_lines == [
             "2 node(s) to be reused:",
-            "1 of 2 REUSED node_1 - reason_1. Last updated: 2026-01-01 00:00:00",
-            "2 of 2 REUSED node_2 - Brand new node. Last updated: none",
+            "1 of 2 REUSED node_1 - reason_1 (last updated: 2026-01-01 00:00:00)",
+            "2 of 2 REUSED node_2 - Brand new node (last updated: none)",
         ]

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+import pytest
+
 from src.orchestra_dbt.constants import ORCHESTRA_REUSED_NODE
 from src.orchestra_dbt.patcher import patch_file, revert_patch_file
 
@@ -8,9 +12,14 @@ class TestPatchFile:
         original_content = "SELECT * FROM customers"
         sql_file.write_text(original_content, encoding="utf-8")
 
-        patch_file(file_path=sql_file, reason="Test reason")
+        patch_file(
+            file_path=sql_file,
+            reason="Test \"reason\" with 'quotes'.",
+            freshness=None,
+            last_updated=None,
+        )
 
-        expected_config = f"{{{{ config(tags=[\"{ORCHESTRA_REUSED_NODE}\"], meta={{'orchestra_reused_reason': 'Test reason'}}) }}}}\n\n"
+        expected_config = f"{{{{ config(tags=[\"{ORCHESTRA_REUSED_NODE}\"], meta={{'orchestra_reused_reason': 'Test reason with quotes.'}}) }}}}\n\n"
         assert (
             sql_file.read_text(encoding="utf-8") == expected_config + original_content
         )
@@ -27,10 +36,15 @@ WHERE active = true
 """
         sql_file.write_text(original_content, encoding="utf-8")
 
-        patch_file(file_path=sql_file, reason="Test reason")
+        patch_file(
+            file_path=sql_file,
+            reason="Test reason",
+            freshness=34,
+            last_updated=datetime(2025, 3, 4, 12, 30),
+        )
 
         result = sql_file.read_text(encoding="utf-8")
-        expected_config = f"{{{{ config(tags=[\"{ORCHESTRA_REUSED_NODE}\"], meta={{'orchestra_reused_reason': 'Test reason'}}) }}}}\n\n"
+        expected_config = f"{{{{ config(tags=[\"{ORCHESTRA_REUSED_NODE}\"], meta={{'orchestra_reused_reason': 'Test reason', 'orchestra_freshness': 34, 'orchestra_last_updated': '2025-03-04T12:30:00'}}) }}}}\n\n"
 
         assert result.startswith(expected_config)
         assert "-- This is a comment" in result
@@ -38,10 +52,26 @@ WHERE active = true
         assert "FROM customers" in result
         assert "old_tag" in result
 
-    def test_revert_patch_file(self, tmp_path):
+    @pytest.mark.parametrize(
+        "freshness, last_updated",
+        [
+            (None, None),
+            (1, None),
+            (None, datetime(2025, 3, 4, 12, 30)),
+            (240, datetime(2025, 3, 4, 12, 30)),
+        ],
+    )
+    def test_revert_patch_file(
+        self, tmp_path, freshness: int | None, last_updated: datetime | None
+    ):
         sql_file = tmp_path / "test_model.sql"
         original_content = "\n\tTEST_CONTENT\n"
         sql_file.write_text(original_content, encoding="utf-8")
-        patch_file(file_path=sql_file, reason="Test reason")
+        patch_file(
+            file_path=sql_file,
+            reason="Test reason",
+            freshness=freshness,
+            last_updated=last_updated,
+        )
         revert_patch_file(file_path=sql_file)
         assert sql_file.read_text(encoding="utf-8") == original_content

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ wheels = [
 
 [[package]]
 name = "orchestra-dbt"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- include `orchestra_freshness` and `orchestra_last_updated ` on meta config of models being reused
- update patching of file to handle this
- fix bug with not being able to run some tests after cloning repo

<img width="599" height="257" alt="Screenshot 2026-01-20 at 12 22 52" src="https://github.com/user-attachments/assets/3447bc73-687a-4049-ada1-a77401522c0c" />
