### PR TITLE
[FIX] Run models that are from external packages and without any parent deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,4 @@ local_state.json
 ops_dag.html
 ops.json
 visualise.py
+example_v2/

--- a/src/orchestra_dbt/dag.py
+++ b/src/orchestra_dbt/dag.py
@@ -20,7 +20,6 @@ def calculate_freshness_on_node(
     resource_type: str,
     track_state: bool,
     from_external_package: bool,
-    materialized_config: str | None,
     depends_on_nodes: list[str] | None,
 ) -> tuple[Freshness, str]:
     if resource_type == "snapshot":
@@ -31,14 +30,10 @@ def calculate_freshness_on_node(
     if not track_state:
         return Freshness.DIRTY, "State orchestration for this node is disabled."
 
-    if (
-        from_external_package
-        and materialized_config == "incremental"
-        and not depends_on_nodes
-    ):
+    if from_external_package and not depends_on_nodes:
         return (
             Freshness.DIRTY,
-            "Incremental model from external package without parent dependencies - skipping state orchestration.",
+            "Model from external package without parent dependencies - skipping state orchestration.",
         )
 
     if resource_type == "seed":
@@ -87,7 +82,6 @@ def construct_dag(
                     node["package_name"] != project_name_from_manifest
                 )
                 depends_on_nodes = node.get("depends_on", {}).get("nodes", [])
-                materialized_config = node.get("config", {}).get("materialized")
                 if from_external_package:
                     file_path = f"dbt_packages/{node['package_name']}/{dbt_path}"
                 else:
@@ -110,7 +104,6 @@ def construct_dag(
                     resource_type,
                     track_state,
                     from_external_package,
-                    materialized_config,
                     depends_on_nodes,
                 )
 

--- a/src/orchestra_dbt/dag.py
+++ b/src/orchestra_dbt/dag.py
@@ -19,6 +19,9 @@ def calculate_freshness_on_node(
     state: StateApiModel,
     resource_type: str,
     track_state: bool,
+    from_external_package: bool,
+    materialized_config: str | None,
+    depends_on_nodes: list[str] | None,
 ) -> tuple[Freshness, str]:
     if resource_type == "snapshot":
         # Note: currently, we always run snapshots. Need to configure how to propagate
@@ -27,6 +30,16 @@ def calculate_freshness_on_node(
 
     if not track_state:
         return Freshness.DIRTY, "State orchestration for this node is disabled."
+
+    if (
+        from_external_package
+        and materialized_config == "incremental"
+        and not depends_on_nodes
+    ):
+        return (
+            Freshness.DIRTY,
+            "Incremental model from external package without parent dependencies - skipping state orchestration.",
+        )
 
     if resource_type == "seed":
         return Freshness.DIRTY, "State orchestration for seeds currently disabled."
@@ -70,7 +83,12 @@ def construct_dag(
                     asset_external_id = f"{integration_account_id}.{node_id}"
 
                 dbt_path = str(node["original_file_path"])
-                if node["package_name"] != project_name_from_manifest:
+                from_external_package = (
+                    node["package_name"] != project_name_from_manifest
+                )
+                depends_on_nodes = node.get("depends_on", {}).get("nodes", [])
+                materialized_config = node.get("config", {}).get("materialized")
+                if from_external_package:
                     file_path = f"dbt_packages/{node['package_name']}/{dbt_path}"
                 else:
                     file_path = dbt_path
@@ -91,6 +109,9 @@ def construct_dag(
                     state,
                     resource_type,
                     track_state,
+                    from_external_package,
+                    materialized_config,
+                    depends_on_nodes,
                 )
 
                 nodes[node_id] = MaterialisationNode(
@@ -114,7 +135,7 @@ def construct_dag(
                     ),
                 )
 
-                for dep in node.get("depends_on", {}).get("nodes", []):
+                for dep in depends_on_nodes:
                     edges.append(Edge(from_=str(dep), to_=node_id))
             case _:
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def sample_manifest():
             "model.test_project_2.model_b": {
                 "resource_type": "model",
                 "checksum": {"checksum": "ghi789"},
-                "config": {"freshness": None},
+                "config": {"freshness": None, "materialized": "incremental"},
                 "package_name": "test_project_2",
                 "original_file_path": "models/model_b.sql",
                 "depends_on": {

--- a/tests/unit/test_dag.py
+++ b/tests/unit/test_dag.py
@@ -24,7 +24,6 @@ class TestCalculateFreshnessOnNode:
             resource_type="snapshot",
             track_state=True,
             from_external_package=False,
-            materialized_config="table",
             depends_on_nodes=[],
         ) == (Freshness.DIRTY, "Snapshot is always dirty.")
 
@@ -36,7 +35,6 @@ class TestCalculateFreshnessOnNode:
             resource_type="seed",
             track_state=False,
             from_external_package=False,
-            materialized_config="table",
             depends_on_nodes=[],
         ) == (Freshness.DIRTY, "State orchestration for this node is disabled.")
 
@@ -48,7 +46,6 @@ class TestCalculateFreshnessOnNode:
             resource_type="model",
             track_state=True,
             from_external_package=False,
-            materialized_config="table",
             depends_on_nodes=[],
         ) == (Freshness.DIRTY, "Model not previously seen in state.")
 
@@ -68,7 +65,6 @@ class TestCalculateFreshnessOnNode:
             resource_type="model",
             track_state=True,
             from_external_package=False,
-            materialized_config="table",
             depends_on_nodes=[],
         ) == (Freshness.DIRTY, "Checksum changed since last run.")
 
@@ -88,11 +84,10 @@ class TestCalculateFreshnessOnNode:
             resource_type="model",
             track_state=True,
             from_external_package=False,
-            materialized_config="table",
             depends_on_nodes=[],
         ) == (Freshness.CLEAN, "Model in same state as last run.")
 
-    def test_calculate_freshness_on_node_incremental_model_from_external_package_with_dependencies(
+    def test_calculate_freshness_on_model_from_external_package_without_dependencies(
         self,
     ):
         assert calculate_freshness_on_node(
@@ -110,11 +105,10 @@ class TestCalculateFreshnessOnNode:
             resource_type="model",
             track_state=True,
             from_external_package=True,
-            materialized_config="incremental",
             depends_on_nodes=[],
         ) == (
             Freshness.DIRTY,
-            "Incremental model from external package without parent dependencies - skipping state orchestration.",
+            "Model from external package without parent dependencies - skipping state orchestration.",
         )
 
 

--- a/tests/unit/test_dag.py
+++ b/tests/unit/test_dag.py
@@ -23,6 +23,9 @@ class TestCalculateFreshnessOnNode:
             state=StateApiModel(state={}),
             resource_type="snapshot",
             track_state=True,
+            from_external_package=False,
+            materialized_config="table",
+            depends_on_nodes=[],
         ) == (Freshness.DIRTY, "Snapshot is always dirty.")
 
     def test_calculate_freshness_on_node_not_tracking_state(self):
@@ -32,6 +35,9 @@ class TestCalculateFreshnessOnNode:
             state=StateApiModel(state={}),
             resource_type="seed",
             track_state=False,
+            from_external_package=False,
+            materialized_config="table",
+            depends_on_nodes=[],
         ) == (Freshness.DIRTY, "State orchestration for this node is disabled.")
 
     def test_calculate_freshness_on_node_not_in_state(self):
@@ -41,6 +47,9 @@ class TestCalculateFreshnessOnNode:
             state=StateApiModel(state={}),
             resource_type="model",
             track_state=True,
+            from_external_package=False,
+            materialized_config="table",
+            depends_on_nodes=[],
         ) == (Freshness.DIRTY, "Model not previously seen in state.")
 
     def test_calculate_freshness_on_node_checksum_changed(self):
@@ -58,6 +67,9 @@ class TestCalculateFreshnessOnNode:
             ),
             resource_type="model",
             track_state=True,
+            from_external_package=False,
+            materialized_config="table",
+            depends_on_nodes=[],
         ) == (Freshness.DIRTY, "Checksum changed since last run.")
 
     def test_calculate_freshness_on_node_checksum_matches(self):
@@ -75,7 +87,35 @@ class TestCalculateFreshnessOnNode:
             ),
             resource_type="model",
             track_state=True,
+            from_external_package=False,
+            materialized_config="table",
+            depends_on_nodes=[],
         ) == (Freshness.CLEAN, "Model in same state as last run.")
+
+    def test_calculate_freshness_on_node_incremental_model_from_external_package_with_dependencies(
+        self,
+    ):
+        assert calculate_freshness_on_node(
+            asset_external_id="test.model.a.b",
+            checksum="123",
+            state=StateApiModel(
+                state={
+                    "test.model.a.b": StateItem(
+                        last_updated=datetime(2024, 1, 1, 12, 0, 0),
+                        checksum="123",
+                        sources={},
+                    ),
+                }
+            ),
+            resource_type="model",
+            track_state=True,
+            from_external_package=True,
+            materialized_config="incremental",
+            depends_on_nodes=[],
+        ) == (
+            Freshness.DIRTY,
+            "Incremental model from external package without parent dependencies - skipping state orchestration.",
+        )
 
 
 class TestConstructDag:


### PR DESCRIPTION
There is a scenario where we are reusing models incorrectly:

- the model is coming from an external package
- no upstream deps

If these are true, we should mark the model as having new data to avoid any downstream issues.