### PR TITLE
FIX: Fix upload of state timing out issue

### DIFF
--- a/src/orchestra_dbt/state.py
+++ b/src/orchestra_dbt/state.py
@@ -120,8 +120,11 @@ def save_state(state: StateApiModel) -> None:
             },
             json=json.loads(state.model_dump_json(exclude_none=True)),
             url=f"{_get_base_api_url()}/state/DBT_CORE",
+            timeout=httpx.Timeout(timeout=30),
         )
         response.raise_for_status()
         log_info("State saved")
     except httpx.HTTPStatusError as e:
         log_warn(f"Failed to save state ({e.response.status_code}): {e.response.text}")
+    except httpx.TimeoutException as e:
+        log_warn(f"Failed to save state due to timeout: {e}")

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest.mock import patch
 
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -164,6 +165,18 @@ class TestSaveState:
                 "Authorization": "Bearer test-api-key",
             },
             status_code=500,
+        )
+        assert save_state(state=StateApiModel(state={})) is None
+
+    def test_save_state_timeout(self, httpx_mock: HTTPXMock):
+        httpx_mock.add_exception(
+            httpx.TimeoutException("Request timed out"),
+            method="PATCH",
+            url="https://dev.getorchestra.io/api/engine/public/state/DBT_CORE",
+            match_headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer test-api-key",
+            },
         )
         assert save_state(state=StateApiModel(state={})) is None
 


### PR DESCRIPTION
Default timeout of 5s for an endpoint that was taking ~10s was causing the task to fail erroneously. Changes:

- increase all timeouts on the PATCH of state to 30s
- error handle httpx read timeout issues cleanly

In future, may need to break up the uploading of state into chunks. Based on current Sentry API data, don't believe that is required right now. Should also mention that state is actually being stored correctly still as the backend continues processing it.