### PR TITLE
[ENG-8940] Improve how asset external ID is stored

### DIFF
--- a/src/orchestra_dbt/asset_external_id.py
+++ b/src/orchestra_dbt/asset_external_id.py
@@ -1,0 +1,17 @@
+from .logger import log_warn
+
+
+def generate_asset_external_id(
+    node_id: str, node: dict, integration_account_id: str | None
+) -> str:
+    if not integration_account_id:
+        return node_id
+
+    relation_name = node.get("relation_name")
+    if not relation_name:
+        log_warn(
+            f"No relation name found for node '{node_id}'. Using node ID as the asset external ID."
+        )
+        return f"{integration_account_id}.{node_id}"
+
+    return f"{integration_account_id}.{relation_name}"

--- a/src/orchestra_dbt/asset_external_id.py
+++ b/src/orchestra_dbt/asset_external_id.py
@@ -2,12 +2,11 @@ from .logger import log_warn
 
 
 def generate_asset_external_id(
-    node_id: str, node: dict, integration_account_id: str | None
+    node_id: str, relation_name: str | None, integration_account_id: str | None
 ) -> str:
     if not integration_account_id:
         return node_id
 
-    relation_name = node.get("relation_name")
     if not relation_name:
         log_warn(
             f"No relation name found for node '{node_id}'. Using node ID as the asset external ID."

--- a/src/orchestra_dbt/dag.py
+++ b/src/orchestra_dbt/dag.py
@@ -1,5 +1,7 @@
+from .asset_external_id import generate_asset_external_id
 from .build_after import parse_freshness_config
 from .checksum import calculate_checksum
+from .logger import log_warn
 from .models import (
     Edge,
     Freshness,
@@ -60,6 +62,11 @@ def construct_dag(
     edges: list[Edge] = []
 
     project_name_from_manifest = manifest["metadata"]["project_name"]
+    integration_account_id = get_integration_account_id_from_env()
+    if not integration_account_id:
+        log_warn(
+            "No integration account ID found. Will use node ID as the asset external ID."
+        )
 
     for node_id in manifest.get("child_map", {}).keys():
         node_id = str(node_id)
@@ -73,9 +80,9 @@ def construct_dag(
         match resource_type:
             case "seed" | "model" | "snapshot":
                 node_id: str = str(node_id)
-                asset_external_id = node_id
-                if integration_account_id := get_integration_account_id_from_env():
-                    asset_external_id = f"{integration_account_id}.{node_id}"
+                asset_external_id: str = generate_asset_external_id(
+                    node_id, node, integration_account_id
+                )
 
                 dbt_path = str(node["original_file_path"])
                 from_external_package = (

--- a/src/orchestra_dbt/dag.py
+++ b/src/orchestra_dbt/dag.py
@@ -81,7 +81,9 @@ def construct_dag(
             case "seed" | "model" | "snapshot":
                 node_id: str = str(node_id)
                 asset_external_id: str = generate_asset_external_id(
-                    node_id, node, integration_account_id
+                    node_id=node_id,
+                    relation_name=node.get("relation_name"),
+                    integration_account_id=integration_account_id,
                 )
 
                 dbt_path = str(node["original_file_path"])
@@ -115,6 +117,7 @@ def construct_dag(
                 )
 
                 nodes[node_id] = MaterialisationNode(
+                    asset_external_id=asset_external_id,
                     checksum=checksum,
                     freshness_config=parse_freshness_config(
                         config_on_node=node.get("config", {}).get("freshness")

--- a/src/orchestra_dbt/models.py
+++ b/src/orchestra_dbt/models.py
@@ -47,6 +47,7 @@ class SourceNode(Node):
 class MaterialisationNode(Node):
     node_type: NodeType = NodeType.MATERIALISATION
 
+    asset_external_id: str
     checksum: str
     dbt_path: str
     file_path: str

--- a/src/orchestra_dbt/state.py
+++ b/src/orchestra_dbt/state.py
@@ -100,11 +100,7 @@ def update_state(
                     ):
                         sources_dict[edge.from_] = source_freshness.sources[edge.from_]
 
-        asset_external_id = node_id
-        if integration_account_id := get_integration_account_id_from_env():
-            asset_external_id = f"{integration_account_id}.{node_id}"
-
-        state.state[asset_external_id] = StateItem(
+        state.state[materialisation_node.asset_external_id] = StateItem(
             checksum=materialisation_node.checksum,
             last_updated=last_updated_from_run_results,
             sources=sources_dict,

--- a/tests/unit/test_asset_external_id.py
+++ b/tests/unit/test_asset_external_id.py
@@ -5,32 +5,36 @@ from src.orchestra_dbt.asset_external_id import generate_asset_external_id
 
 class TestGenerateAssetExternalId:
     @pytest.mark.parametrize(
-        argnames="node_id, node, integration_account_id, expected",
+        argnames="node_id, relation_name, integration_account_id, expected",
         argvalues=[
             (
                 "model.a",
-                {"relation_name": "a.b.c"},
+                "a.b.c",
                 None,
                 "model.a",
             ),
             (
                 "model.a",
-                {},
+                None,
                 "integration_account_id",
                 "integration_account_id.model.a",
             ),
             (
                 "model.a",
-                {"relation_name": "a.b.c"},
+                "a.b.c",
                 "integration_account_id",
                 "integration_account_id.a.b.c",
             ),
         ],
     )
     def test_generate_asset_external_id(
-        self, node_id: str, node: dict, integration_account_id: str, expected: str
+        self,
+        node_id: str,
+        relation_name: str | None,
+        integration_account_id: str | None,
+        expected: str,
     ):
         assert (
-            generate_asset_external_id(node_id, node, integration_account_id)
+            generate_asset_external_id(node_id, relation_name, integration_account_id)
             == expected
         )

--- a/tests/unit/test_asset_external_id.py
+++ b/tests/unit/test_asset_external_id.py
@@ -1,0 +1,36 @@
+import pytest
+
+from src.orchestra_dbt.asset_external_id import generate_asset_external_id
+
+
+class TestGenerateAssetExternalId:
+    @pytest.mark.parametrize(
+        argnames="node_id, node, integration_account_id, expected",
+        argvalues=[
+            (
+                "model.a",
+                {"relation_name": "a.b.c"},
+                None,
+                "model.a",
+            ),
+            (
+                "model.a",
+                {},
+                "integration_account_id",
+                "integration_account_id.model.a",
+            ),
+            (
+                "model.a",
+                {"relation_name": "a.b.c"},
+                "integration_account_id",
+                "integration_account_id.a.b.c",
+            ),
+        ],
+    )
+    def test_generate_asset_external_id(
+        self, node_id: str, node: dict, integration_account_id: str, expected: str
+    ):
+        assert (
+            generate_asset_external_id(node_id, node, integration_account_id)
+            == expected
+        )

--- a/tests/unit/test_build_after.py
+++ b/tests/unit/test_build_after.py
@@ -78,6 +78,7 @@ class TestPropagateFreshnessConfig:
         dag = ParsedDag(
             nodes={
                 "A": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/a.sql",
@@ -87,6 +88,7 @@ class TestPropagateFreshnessConfig:
                     freshness_config=FreshnessConfig(),  # No config
                 ),
                 "B": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.b",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/b.sql",
@@ -96,6 +98,7 @@ class TestPropagateFreshnessConfig:
                     freshness_config=FreshnessConfig(),  # No config
                 ),
                 "C": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.c",
                     freshness=Freshness.CLEAN,
                     checksum="3",
                     dbt_path="models/c.sql",
@@ -132,6 +135,7 @@ class TestPropagateFreshnessConfig:
         dag = ParsedDag(
             nodes={
                 "A": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/a.sql",
@@ -143,6 +147,7 @@ class TestPropagateFreshnessConfig:
                     ),  # Already has config
                 ),
                 "B": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.b",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/b.sql",
@@ -152,6 +157,7 @@ class TestPropagateFreshnessConfig:
                     freshness_config=FreshnessConfig(),  # No config
                 ),
                 "C": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.c",
                     freshness=Freshness.CLEAN,
                     checksum="3",
                     dbt_path="models/c.sql",
@@ -161,6 +167,7 @@ class TestPropagateFreshnessConfig:
                     freshness_config=FreshnessConfig(),  # No config
                 ),
                 "D": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.d",
                     freshness=Freshness.CLEAN,
                     checksum="4",
                     dbt_path="models/d.sql",
@@ -204,6 +211,7 @@ class TestPropagateFreshnessConfig:
         dag = ParsedDag(
             nodes={
                 "A": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/a.sql",
@@ -213,6 +221,7 @@ class TestPropagateFreshnessConfig:
                     freshness_config=FreshnessConfig(),  # No config
                 ),
                 "B": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.b",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/b.sql",
@@ -222,6 +231,7 @@ class TestPropagateFreshnessConfig:
                     freshness_config=FreshnessConfig(minutes_sla=10),
                 ),
                 "C": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.c",
                     freshness=Freshness.CLEAN,
                     checksum="3",
                     dbt_path="models/c.sql",
@@ -249,6 +259,7 @@ class TestPropagateFreshnessConfig:
         dag = ParsedDag(
             nodes={
                 "A": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/a.sql",
@@ -258,6 +269,7 @@ class TestPropagateFreshnessConfig:
                     freshness_config=FreshnessConfig(minutes_sla=20),  # Has config
                 ),
                 "B": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.b",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/b.sql",
@@ -287,6 +299,7 @@ class TestPropagateFreshnessConfig:
         dag = ParsedDag(
             nodes={
                 "A": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/a.sql",
@@ -296,6 +309,7 @@ class TestPropagateFreshnessConfig:
                     freshness_config=FreshnessConfig(),  # No config
                 ),
                 "B": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.b",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/b.sql",
@@ -327,6 +341,7 @@ class TestPropagateFreshnessConfig:
         dag = ParsedDag(
             nodes={
                 "A": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/a.sql",
@@ -338,6 +353,7 @@ class TestPropagateFreshnessConfig:
                     ),  # No minutes_sla but has updates_on
                 ),
                 "B": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.b",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/b.sql",

--- a/tests/unit/test_dag.py
+++ b/tests/unit/test_dag.py
@@ -156,6 +156,7 @@ class TestConstructDag:
                     last_updated=datetime(2024, 1, 3, 12, 0, 0),
                 ),
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.test_project.model_a",
                     freshness=Freshness.CLEAN,
                     last_updated=datetime(2024, 1, 1, 12, 0, 0),
                     checksum="def456",
@@ -170,6 +171,7 @@ class TestConstructDag:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.test_project_2.model_b": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.test_project_2.model_b",
                     freshness=Freshness.DIRTY,
                     checksum="ghi789",
                     dbt_path="models/model_b.sql",
@@ -179,6 +181,7 @@ class TestConstructDag:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.test_project.model_c": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.test_project.model_c",
                     freshness=Freshness.DIRTY,
                     last_updated=datetime(2024, 1, 1, 12, 0, 0),
                     checksum="456",

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -12,6 +12,7 @@ class TestLogReusedNodes:
     def test_happy_path_formatting(self, capsys):
         nodes_to_reuse = {
             "node_1": MaterialisationNode(
+                asset_external_id="integration_account_id.model.node_1",
                 last_updated=datetime(2026, 1, 1),
                 checksum="checksum_1",
                 freshness_config=FreshnessConfig(),
@@ -22,6 +23,7 @@ class TestLogReusedNodes:
                 file_path="file_path_1",
             ),
             "node_2": MaterialisationNode(
+                asset_external_id="integration_account_id.model.node_2",
                 last_updated=None,
                 checksum="checksum_1",
                 freshness_config=FreshnessConfig(),

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -86,6 +86,7 @@ WHERE active = true
 class TestPatchSeedProperties:
     SEEDS_TO_REUSE = {
         "seed_1": MaterialisationNode(
+            asset_external_id="integration_account_id.seed_1",
             checksum="checksum_1",
             dbt_path="dbt_path_1",
             file_path="seeds/some_path/seed_1.csv",
@@ -96,6 +97,7 @@ class TestPatchSeedProperties:
             reason="Seed seed_1 in same state as before.",
         ),
         "seed_2": MaterialisationNode(
+            asset_external_id="integration_account_id.seed_2",
             checksum="checksum_2",
             dbt_path="dbt_path_2",
             file_path="seed_2.csv",

--- a/tests/unit/test_sao.py
+++ b/tests/unit/test_sao.py
@@ -25,6 +25,7 @@ class TestBuildDependencyGraphs:
             dag=ParsedDag(
                 nodes={
                     "model.a": MaterialisationNode(
+                        asset_external_id="model.a",
                         freshness=Freshness.CLEAN,
                         checksum="1",
                         dbt_path="models/model_a.sql",
@@ -34,6 +35,7 @@ class TestBuildDependencyGraphs:
                         freshness_config=FreshnessConfig(),
                     ),
                     "model.b": MaterialisationNode(
+                        asset_external_id="model.b",
                         freshness=Freshness.CLEAN,
                         checksum="2",
                         dbt_path="models/model_b.sql",
@@ -43,6 +45,7 @@ class TestBuildDependencyGraphs:
                         freshness_config=FreshnessConfig(),
                     ),
                     "model.c": MaterialisationNode(
+                        asset_external_id="model.c",
                         freshness=Freshness.CLEAN,
                         checksum="3",
                         dbt_path="models/model_c.sql",
@@ -52,6 +55,7 @@ class TestBuildDependencyGraphs:
                         freshness_config=FreshnessConfig(),
                     ),
                     "model.d": MaterialisationNode(
+                        asset_external_id="model.d",
                         freshness=Freshness.CLEAN,
                         checksum="4",
                         dbt_path="models/model_d.sql",
@@ -96,6 +100,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                 "source.test",
                 SourceNode(),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -115,6 +120,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                     last_updated=datetime.now() - timedelta(minutes=10),
                 ),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -133,6 +139,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                 "source.test",
                 SourceNode(last_updated=datetime.now()),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -151,6 +158,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                 "source.test",
                 SourceNode(last_updated=datetime.now() - timedelta(minutes=10)),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -169,6 +177,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                 "source.test",
                 SourceNode(last_updated=datetime.now()),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -192,6 +201,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                 "source.test",
                 SourceNode(last_updated=datetime.now()),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -209,6 +219,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
             (
                 "model.a",
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -219,6 +230,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                     freshness_config=FreshnessConfig(),
                 ),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.b",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_b.sql",
@@ -234,6 +246,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
             (
                 "model.a",
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -244,6 +257,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                     freshness_config=FreshnessConfig(),
                 ),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.b",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_b.sql",
@@ -259,6 +273,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
             (
                 "model.a",
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -269,6 +284,7 @@ class TestShouldMarkDirtyFromSingleUpstream:
                     freshness_config=FreshnessConfig(),
                 ),
                 MaterialisationNode(
+                    asset_external_id="integration_account_id.model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_b.sql",
@@ -308,6 +324,7 @@ class TestCalculateModelsToRun:
                     last_updated=datetime.now(),
                 ),
                 "model.a": MaterialisationNode(
+                    asset_external_id="model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -317,6 +334,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.b": MaterialisationNode(
+                    asset_external_id="model.b",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/model_b.sql",
@@ -350,6 +368,7 @@ class TestCalculateModelsToRun:
                     last_updated=datetime.now() - timedelta(minutes=10),
                 ),
                 "model.a": MaterialisationNode(
+                    asset_external_id="model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -379,6 +398,7 @@ class TestCalculateModelsToRun:
                     last_updated=datetime.now(),
                 ),
                 "model.a": MaterialisationNode(
+                    asset_external_id="model.a",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -411,6 +431,7 @@ class TestCalculateModelsToRun:
         dag = ParsedDag(
             nodes={
                 "model.a": MaterialisationNode(
+                    asset_external_id="model.a",
                     freshness=Freshness.DIRTY,
                     checksum="1",
                     dbt_path="models/model_a.sql",
@@ -421,6 +442,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.b": MaterialisationNode(
+                    asset_external_id="model.b",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/model_b.sql",
@@ -431,6 +453,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.c": MaterialisationNode(
+                    asset_external_id="model.c",
                     freshness=Freshness.CLEAN,
                     checksum="3",
                     dbt_path="models/model_c.sql",
@@ -467,6 +490,7 @@ class TestCalculateModelsToRun:
                     last_updated=now,
                 ),
                 "model.stg_orders": MaterialisationNode(
+                    asset_external_id="model.stg_orders",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_stg_orders.sql",
@@ -479,6 +503,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.stg_customers": MaterialisationNode(
+                    asset_external_id="model.stg_customers",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/model_stg_customers.sql",
@@ -491,6 +516,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.int_orders": MaterialisationNode(
+                    asset_external_id="model.int_orders",
                     freshness=Freshness.CLEAN,
                     checksum="3",
                     dbt_path="models/model_int_orders.sql",
@@ -501,6 +527,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.dim_customers": MaterialisationNode(
+                    asset_external_id="model.dim_customers",
                     freshness=Freshness.CLEAN,
                     checksum="4",
                     dbt_path="models/model_dim_customers.sql",
@@ -511,6 +538,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.cust_orders": MaterialisationNode(
+                    asset_external_id="model.cust_orders",
                     freshness=Freshness.CLEAN,
                     checksum="5",
                     dbt_path="models/model_cust_orders.sql",
@@ -569,6 +597,7 @@ class TestCalculateModelsToRun:
                     last_updated=now - timedelta(minutes=5),
                 ),
                 "model.stg_orders": MaterialisationNode(
+                    asset_external_id="model.stg_orders",
                     freshness=Freshness.CLEAN,
                     checksum="1",
                     dbt_path="models/model_stg_orders.sql",
@@ -581,6 +610,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.stg_customers": MaterialisationNode(
+                    asset_external_id="model.stg_customers",
                     freshness=Freshness.CLEAN,
                     checksum="2",
                     dbt_path="models/model_stg_customers.sql",
@@ -593,6 +623,7 @@ class TestCalculateModelsToRun:
                     reason="Node not seen before",
                 ),
                 "model.int_orders": MaterialisationNode(
+                    asset_external_id="model.int_orders",
                     freshness=Freshness.CLEAN,
                     checksum="3",
                     dbt_path="models/model_int_orders.sql",
@@ -603,6 +634,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.dim_customers": MaterialisationNode(
+                    asset_external_id="model.dim_customers",
                     freshness=Freshness.CLEAN,
                     checksum="4",
                     dbt_path="models/model_dim_customers.sql",
@@ -613,6 +645,7 @@ class TestCalculateModelsToRun:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.cust_orders": MaterialisationNode(
+                    asset_external_id="model.cust_orders",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_cust_orders.sql",
                     file_path="models/model_cust_orders.sql",

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -207,6 +207,7 @@ class TestUpdateState:
         parsed_dag = ParsedDag(
             nodes={
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -250,6 +251,7 @@ class TestUpdateState:
             nodes={
                 "source.test_db.test_schema.test_table": SourceNode(),
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -288,6 +290,7 @@ class TestUpdateState:
         parsed_dag = ParsedDag(
             nodes={
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -325,6 +328,7 @@ class TestUpdateState:
         parsed_dag = ParsedDag(
             nodes={
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -399,6 +403,7 @@ class TestUpdateState:
         parsed_dag = ParsedDag(
             nodes={
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -408,6 +413,7 @@ class TestUpdateState:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.test_project.model_b": MaterialisationNode(
+                    asset_external_id="model.test_project.model_b",
                     checksum="def456",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_b.sql",
@@ -451,6 +457,7 @@ class TestUpdateState:
                 "source.test_db.test_schema.table1": SourceNode(),
                 "source.test_db.test_schema.table2": SourceNode(),
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -513,6 +520,7 @@ class TestUpdateState:
                 "source.test_db.test_schema.table1": SourceNode(),
                 "source.test_db.test_schema.table2": SourceNode(),
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -583,6 +591,7 @@ class TestUpdateState:
         parsed_dag = ParsedDag(
             nodes={
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="model.test_project.model_a",
                     checksum="new_checksum",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -623,6 +632,7 @@ class TestUpdateState:
         parsed_dag = ParsedDag(
             nodes={
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -632,6 +642,7 @@ class TestUpdateState:
                     freshness_config=FreshnessConfig(),
                 ),
                 "model.test_project.model_b": MaterialisationNode(
+                    asset_external_id="model.test_project.model_b",
                     checksum="def456",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_b.sql",
@@ -673,6 +684,7 @@ class TestUpdateState:
         parsed_dag = ParsedDag(
             nodes={
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="integration_account_id.model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",
@@ -707,6 +719,7 @@ class TestUpdateState:
         parsed_dag = ParsedDag(
             nodes={
                 "model.test_project.model_a": MaterialisationNode(
+                    asset_external_id="model.test_project.model_a",
                     checksum="abc123",
                     freshness=Freshness.CLEAN,
                     dbt_path="models/model_a.sql",


### PR DESCRIPTION
There was an issue where the same asset external ID was being stored in state, but they are referring to a different underlying table in the warehouse. This causes two issues:

- conflicts during state uploads
- invalid data during each run

This PR changes how we store this value. It is still not an _exact_ copy of the value in Orchestra. That is fine for now. This should provide more uniqueness in the value. We will reset all state once this change is tested and released, meaning for one run there will be no SAO available.