### PR TITLE
ENG-9727 Prefer HTTP state when API key is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The CLI discovers `pyproject.toml` by walking upward from the current working di
 
 | Priority | Setting | Effect |
 | --- | --- | --- |
-| 1 | `ORCHESTRA_STATE_FILE` | Path to a JSON file. Relative paths are resolved from the current working directory. |
-| 2 | `[tool.orchestra_dbt]` / `state_file` in `pyproject.toml` | Path to a JSON file. Relative paths are resolved from the directory that contains the **discovered** `pyproject.toml`; absolute paths are used as-is. |
-| 3 | Neither of the above, but `ORCHESTRA_API_KEY` is set | Load/save state via Orchestra HTTP. `ORCHESTRA_ENV` must be one of `app`, `stage`, or `dev` (it defaults to `app` if unset). |
+| 1 | `ORCHESTRA_API_KEY` | Load/save state via Orchestra HTTP. `ORCHESTRA_ENV` must be one of `app`, `stage`, or `dev` (it defaults to `app` if unset). When the API key is set, `ORCHESTRA_STATE_FILE` and `state_file` in `pyproject.toml` are **ignored** for choosing the state backend. |
+| 2 | `ORCHESTRA_STATE_FILE` | Path to a JSON file. Relative paths are resolved from the current working directory. Used only when `ORCHESTRA_API_KEY` is unset. |
+| 3 | `[tool.orchestra_dbt]` / `state_file` in `pyproject.toml` | Path to a JSON file. Relative paths are resolved from the directory that contains the **discovered** `pyproject.toml`; absolute paths are used as-is. Used only when `ORCHESTRA_API_KEY` is unset and `ORCHESTRA_STATE_FILE` is unset. |
 
-If an effective file path is configured (rows 1 or 2), that **file backend** is used and an API key is not required for state. If only `ORCHESTRA_API_KEY` is set (and no file path), the **HTTP backend** is used.
+If an effective file path is configured (rows 2 or 3), that **file backend** is used and an API key is not required for state. If `ORCHESTRA_API_KEY` is set (row 1), the **HTTP backend** is used regardless of file settings.
 
 Stateful orchestration only runs for `dbt build`, `dbt run`, and `dbt test`. Other dbt subcommands are passed through to dbt unchanged.
 
@@ -63,13 +63,13 @@ echo '{"state":{}}' > .orchestra/dbt_state.json
 
 ## Running locally
 
-Orchestra HTTP (requires an API key from Orchestra). Do not set `ORCHESTRA_STATE_FILE` or `state_file` in `pyproject.toml` if you want the HTTP backend rather than a local file.
+Orchestra HTTP (requires an API key from Orchestra). Setting `ORCHESTRA_API_KEY` selects the HTTP backend; file-related settings are ignored.
 
 ```bash
 ORCHESTRA_ENV=dev ORCHESTRA_API_KEY=<API_KEY> ORCHESTRA_USE_STATEFUL=true ORCHESTRA_LOCAL_RUN=true orchestra-dbt dbt run --target snowflake
 ```
 
-Local JSON file (after creating the file as above), no Orchestra API key required for state:
+Local JSON file (after creating the file as above): **unset** `ORCHESTRA_API_KEY` so `ORCHESTRA_STATE_FILE` or `state_file` in `pyproject.toml` is used.
 
 ```bash
 ORCHESTRA_USE_STATEFUL=true ORCHESTRA_STATE_FILE=.orchestra/dbt_state.json ORCHESTRA_LOCAL_RUN=true orchestra-dbt dbt run --target snowflake

--- a/src/orchestra_dbt/cli.py
+++ b/src/orchestra_dbt/cli.py
@@ -44,9 +44,8 @@ def _validate_environment() -> None:
 
     if not os.getenv("ORCHESTRA_API_KEY"):
         log_error(
-            "Stateful mode requires a state file (ORCHESTRA_STATE_FILE or "
-            "[tool.orchestra_dbt] state_file in pyproject.toml) or ORCHESTRA_API_KEY "
-            "for Orchestra HTTP."
+            "Stateful mode requires ORCHESTRA_API_KEY for Orchestra HTTP, or a state file "
+            "(ORCHESTRA_STATE_FILE or [tool.orchestra_dbt] state_file in pyproject.toml)."
         )
         sys.exit(1)
 

--- a/src/orchestra_dbt/config.py
+++ b/src/orchestra_dbt/config.py
@@ -26,6 +26,9 @@ def _read_tool_orchestra_dbt(project_dir: Path) -> dict:
 
 
 def effective_state_file_path(cwd: Path | None = None) -> Path | None:
+    if os.getenv("ORCHESTRA_API_KEY", "").strip():
+        return None
+
     env_path = os.getenv("ORCHESTRA_STATE_FILE", "").strip()
     base = cwd or Path.cwd()
     if env_path:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,6 +14,7 @@ def test_effective_state_file_path_env_overrides_pyproject(
     )
     other = tmp_path / "from_env.json"
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
     monkeypatch.setenv("ORCHESTRA_STATE_FILE", str(other))
     assert effective_state_file_path() == other.resolve()
 
@@ -26,6 +27,7 @@ def test_effective_state_file_path_from_pyproject_relative(
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
     monkeypatch.delenv("ORCHESTRA_STATE_FILE", raising=False)
     expected = (tmp_path / ".orchestra" / "state.json").resolve()
     assert effective_state_file_path() == expected
@@ -35,6 +37,7 @@ def test_effective_state_file_path_env_relative_to_cwd(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
     monkeypatch.delenv("ORCHESTRA_STATE_FILE", raising=False)
     monkeypatch.setenv("ORCHESTRA_STATE_FILE", "rel/state.json")
     assert effective_state_file_path() == (tmp_path / "rel" / "state.json").resolve()
@@ -56,5 +59,20 @@ def test_effective_state_file_path_none_without_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
     monkeypatch.delenv("ORCHESTRA_STATE_FILE", raising=False)
+    assert effective_state_file_path() is None
+
+
+def test_effective_state_file_path_api_key_prefers_http_over_env_and_pyproject(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.orchestra_dbt]\nstate_file = "from_pyproject.json"\n',
+        encoding="utf-8",
+    )
+    other = tmp_path / "from_env.json"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ORCHESTRA_API_KEY", "secret")
+    monkeypatch.setenv("ORCHESTRA_STATE_FILE", str(other))
     assert effective_state_file_path() is None

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -742,6 +742,7 @@ class TestUpdateState:
 class TestLoadStateFile:
     def test_load_state_file_missing(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
         monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
         monkeypatch.setenv("ORCHESTRA_STATE_FILE", str(tmp_path / "missing.json"))
 
         with pytest.raises(StateLoadError, match="State file not found"):
@@ -753,6 +754,7 @@ class TestLoadStateFile:
         p = tmp_path / "st.json"
         p.write_text('{"state": {}}', encoding="utf-8")
         monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
         monkeypatch.setenv("ORCHESTRA_STATE_FILE", str(p))
 
         assert load_state() == StateApiModel(state={})
@@ -763,6 +765,7 @@ class TestLoadStateFile:
         p = tmp_path / "st.json"
         p.write_text("not json", encoding="utf-8")
         monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
         monkeypatch.setenv("ORCHESTRA_STATE_FILE", str(p))
 
         with pytest.raises(StateLoadError, match="not valid JSON"):
@@ -776,6 +779,7 @@ class TestSaveStateFile:
         p = tmp_path / "st.json"
         p.write_text('{"state": {}}', encoding="utf-8")
         monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
         monkeypatch.setenv("ORCHESTRA_STATE_FILE", str(p))
         state = StateApiModel(
             state={


### PR DESCRIPTION
<!-- Please ensure that the JIRA ticket ID is included in either the PR title, description, or branch. -->

# Objective
Prefer Orchestra HTTP for dbt state when an API key is present.

## Changes
- Choose HTTP state backend when `ORCHESTRA_API_KEY` is set; otherwise use env file path or `pyproject.toml` as before.
- Document the new priority and migration note in the README.
- Adjust CLI error message to match.

## Testing
Unit tested.

## Checklist
- [ ] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes


Made with [Cursor](https://cursor.com)