### PR TITLE
ENG-9738: Pyproject-driven orchestra-dbt settings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 on:
   pull_request:
-    branches: [ main, release-03 ]
+    branches: [ main, release-03 ] # remove release-03 when all new changes are merged to main
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,9 +12,9 @@ jobs:
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
       - name: Set up Python ${{ matrix.python-version }}
@@ -44,9 +44,9 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
       - name: Set up Python 3.13

--- a/README.md
+++ b/README.md
@@ -31,9 +31,26 @@ Pull requests run GitHub Actions: unit tests, static checks, `dbt build` for `tu
 
 ## Stateful mode and where state is stored
 
-When `ORCHESTRA_USE_STATEFUL=true`, the CLI must load and save [dbt Core state](https://docs.getdbt.com/) metadata used for orchestration. That state is the same JSON shape whether it comes from Orchestra’s HTTP API or from a local file.
+When stateful orchestration is enabled, the CLI loads and saves [dbt Core state](https://docs.getdbt.com/) metadata used for orchestration. Enable it with `use_stateful = true` under `[tool.orchestra_dbt]`, or set `ORCHESTRA_USE_STATEFUL=true`. That state is the same JSON shape whether it comes from Orchestra’s HTTP API or from a local file.
 
 **Do not put secrets in `pyproject.toml`.** Use environment variables (or your platform’s secret store) for `ORCHESTRA_API_KEY`.
+
+### Configuration precedence
+
+For non-secret options, **if an environment variable is set, it overrides** values from `[tool.orchestra_dbt]`; otherwise the value from `pyproject.toml` is used, then the built-in default.
+
+### `[tool.orchestra_dbt]` options
+
+| Key | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `state_file` | string (optional) | — | Local JSON path for state (see backend table below). |
+| `use_stateful` | bool | `false` | Turn on stateful orchestration for supported dbt commands. |
+| `orchestra_env` | string | `app` | Orchestra deployment: `app`, `stage`, or `dev` (HTTP API host). |
+| `local_run` | bool | `false` | After reuse, revert patched files (typical for local iteration). |
+| `debug` | bool | `false` | Verbose `orchestra-dbt` debug logging. |
+| `integration_account_id` | string (optional) | — | When set, filter state keys to this integration account prefix. |
+
+Equivalent environment overrides (when set): `ORCHESTRA_USE_STATEFUL`, `ORCHESTRA_ENV`, `ORCHESTRA_LOCAL_RUN`, `ORCHESTRA_DBT_DEBUG`, `ORCHESTRA_INTEGRATION_ACCOUNT_ID`.
 
 ### Choosing HTTP (Orchestra cloud) vs a local JSON file
 
@@ -41,7 +58,7 @@ The CLI discovers `pyproject.toml` by walking upward from the current working di
 
 | Priority | Setting | Effect |
 | --- | --- | --- |
-| 1 | `ORCHESTRA_API_KEY` | Load/save state via Orchestra HTTP. `ORCHESTRA_ENV` must be one of `app`, `stage`, or `dev` (it defaults to `app` if unset). When the API key is set, `ORCHESTRA_STATE_FILE` and `state_file` in `pyproject.toml` are **ignored** for choosing the state backend. |
+| 1 | `ORCHESTRA_API_KEY` | Load/save state via Orchestra HTTP. The Orchestra environment is `orchestra_env` in pyproject (default `app`) or `ORCHESTRA_ENV` when set; must be one of `app`, `stage`, or `dev`. When the API key is set, `ORCHESTRA_STATE_FILE` and `state_file` in `pyproject.toml` are **ignored** for choosing the state backend. |
 | 2 | `ORCHESTRA_STATE_FILE` | Path to a JSON file. Relative paths are resolved from the current working directory. Used only when `ORCHESTRA_API_KEY` is unset. |
 | 3 | `[tool.orchestra_dbt]` / `state_file` in `pyproject.toml` | Path to a JSON file. Relative paths are resolved from the directory that contains the **discovered** `pyproject.toml`; absolute paths are used as-is. Used only when `ORCHESTRA_API_KEY` is unset and `ORCHESTRA_STATE_FILE` is unset. |
 
@@ -53,6 +70,8 @@ Example optional snippet in `pyproject.toml`:
 
 ```toml
 [tool.orchestra_dbt]
+use_stateful = true
+orchestra_env = "dev"
 state_file = ".orchestra/dbt_state.json"
 ```
 
@@ -69,16 +88,33 @@ echo '{"state":{}}' > .orchestra/dbt_state.json
 
 ## Running locally
 
-Orchestra HTTP (requires an API key from Orchestra). Setting `ORCHESTRA_API_KEY` selects the HTTP backend; file-related settings are ignored.
+Orchestra HTTP (requires an API key from Orchestra). Setting `ORCHESTRA_API_KEY` selects the HTTP backend; file-related settings are ignored. Put non-secret defaults in `pyproject.toml` and only export the API key:
+
+```toml
+[tool.orchestra_dbt]
+use_stateful = true
+orchestra_env = "dev"
+local_run = true
+```
 
 ```bash
-ORCHESTRA_ENV=dev ORCHESTRA_API_KEY=<API_KEY> ORCHESTRA_USE_STATEFUL=true ORCHESTRA_LOCAL_RUN=true orchestra-dbt dbt run --target snowflake
+export ORCHESTRA_API_KEY=<API_KEY>
+orchestra-dbt dbt run --target snowflake
 ```
+
+You can still override with env vars (for example `ORCHESTRA_ENV=stage`) when needed.
 
 Local JSON file (after creating the file as above): **unset** `ORCHESTRA_API_KEY` so `ORCHESTRA_STATE_FILE` or `state_file` in `pyproject.toml` is used.
 
+```toml
+[tool.orchestra_dbt]
+use_stateful = true
+state_file = ".orchestra/dbt_state.json"
+local_run = true
+```
+
 ```bash
-ORCHESTRA_USE_STATEFUL=true ORCHESTRA_STATE_FILE=.orchestra/dbt_state.json ORCHESTRA_LOCAL_RUN=true orchestra-dbt dbt run --target snowflake
+orchestra-dbt dbt run --target snowflake
 ```
 
 ## Running in Orchestra

--- a/src/orchestra_dbt/cli.py
+++ b/src/orchestra_dbt/cli.py
@@ -8,8 +8,8 @@ import click
 
 from .build_after import propagate_freshness_config
 from .compatibility import dbt_core_import_error_message
-from .config import effective_state_file_path
-from .constants import SERVICE_NAME, VALID_ORCHESTRA_ENVS
+from .config import effective_state_file_path, load_orchestra_dbt_settings
+from .constants import SERVICE_NAME
 from .dag import construct_dag
 from .logger import log_debug, log_error, log_info, log_reused_nodes
 from .ls import get_paths_to_run
@@ -49,12 +49,6 @@ def _validate_environment() -> None:
         )
         sys.exit(1)
 
-    if os.getenv("ORCHESTRA_ENV", "app").lower() not in VALID_ORCHESTRA_ENVS:
-        log_error(
-            f"Invalid ORCHESTRA_ENV environment variable. Must be one of: {', '.join(VALID_ORCHESTRA_ENVS)}"
-        )
-        sys.exit(1)
-
     log_debug("Environment validated.")
 
 
@@ -91,7 +85,13 @@ def main(args: tuple):
                 sys.exit(1)
         sys.exit(0)
 
-    if not os.getenv("ORCHESTRA_USE_STATEFUL", "false").lower() == "true":
+    try:
+        settings = load_orchestra_dbt_settings()
+    except ValueError as exc:
+        log_error(str(exc))
+        sys.exit(1)
+
+    if not settings.use_stateful:
         log_debug("Stateful orchestration is disabled. Running dbt command directly.")
         try:
             sys.exit(subprocess.run(args).returncode)
@@ -175,7 +175,7 @@ def main(args: tuple):
         result = subprocess.run(modify_dbt_command(cmd=list(args)))
 
         log_info(f"{len(nodes_to_reuse)}/{node_count} nodes reused.")
-        if os.getenv("ORCHESTRA_LOCAL_RUN", "false").lower() == "true":
+        if settings.local_run:
             revert_patching(
                 file_paths_to_revert=[
                     node.file_path for node in nodes_to_reuse.values()

--- a/src/orchestra_dbt/compatibility.py
+++ b/src/orchestra_dbt/compatibility.py
@@ -2,7 +2,6 @@ SUPPORTED_DBT_CORE_SPEC = ">=1.10,<1.12"
 
 
 def dbt_core_import_error_message(exc: BaseException) -> str:
-    """User-facing text when dbt-core modules cannot be imported."""
     return (
         f"dbt-core is required (supported versions {SUPPORTED_DBT_CORE_SPEC}). "
         f"Install it per README. Import error: {exc}"

--- a/src/orchestra_dbt/config.py
+++ b/src/orchestra_dbt/config.py
@@ -1,8 +1,29 @@
 import os
 import tomllib
 from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 
 _TOOL_SECTION = "orchestra_dbt"
+
+
+class OrchestraDbtSettings(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    state_file: str | None = None
+    use_stateful: bool = False
+    orchestra_env: Literal["app", "stage", "dev"] = "app"
+    local_run: bool = False
+    debug: bool = False
+    integration_account_id: str | None = None
+
+    @field_validator("orchestra_env", mode="before")
+    @classmethod
+    def _normalize_orchestra_env(cls, v: object) -> object:
+        if isinstance(v, str):
+            return v.lower()
+        return v
 
 
 def find_pyproject_directory(start: Path | None = None) -> Path | None:
@@ -23,6 +44,60 @@ def _read_tool_orchestra_dbt(project_dir: Path) -> dict:
         return {}
     section = tool.get(_TOOL_SECTION, {})
     return section if isinstance(section, dict) else {}
+
+
+def _env_bool(name: str) -> bool | None:
+    if name not in os.environ:
+        return None
+    return os.environ[name].lower() == "true"
+
+
+def _env_str(name: str) -> str | None:
+    if name not in os.environ:
+        return None
+    stripped = os.environ[name].strip()
+    return stripped if stripped else None
+
+
+def _merge_env_overrides(settings: OrchestraDbtSettings) -> OrchestraDbtSettings:
+    use_stateful = _env_bool("ORCHESTRA_USE_STATEFUL")
+    if use_stateful is not None:
+        settings = settings.model_copy(update={"use_stateful": use_stateful})
+
+    orchestra_env = _env_str("ORCHESTRA_ENV")
+    if orchestra_env is not None:
+        settings = settings.model_copy(update={"orchestra_env": orchestra_env})
+
+    local_run = _env_bool("ORCHESTRA_LOCAL_RUN")
+    if local_run is not None:
+        settings = settings.model_copy(update={"local_run": local_run})
+
+    if "ORCHESTRA_DBT_DEBUG" in os.environ:
+        debug = os.environ["ORCHESTRA_DBT_DEBUG"].strip().lower() == "true"
+        settings = settings.model_copy(update={"debug": debug})
+
+    integration = _env_str("ORCHESTRA_INTEGRATION_ACCOUNT_ID")
+    if integration is not None:
+        settings = settings.model_copy(update={"integration_account_id": integration})
+
+    return OrchestraDbtSettings.model_validate(settings.model_dump())
+
+
+def load_orchestra_dbt_settings(cwd: Path | None = None) -> OrchestraDbtSettings:
+    base = cwd or Path.cwd()
+    project_dir = find_pyproject_directory(base)
+    raw: dict = {}
+    if project_dir is not None:
+        raw = _read_tool_orchestra_dbt(project_dir)
+    try:
+        settings = OrchestraDbtSettings.model_validate(raw)
+        return _merge_env_overrides(settings)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid [tool.orchestra_dbt] configuration: {exc}") from exc
+
+
+def get_integration_account_id(cwd: Path | None = None) -> str | None:
+    return load_orchestra_dbt_settings(cwd).integration_account_id
 
 
 def effective_state_file_path(cwd: Path | None = None) -> Path | None:

--- a/src/orchestra_dbt/dag.py
+++ b/src/orchestra_dbt/dag.py
@@ -1,6 +1,7 @@
 from .asset_external_id import generate_asset_external_id
 from .build_after import parse_freshness_config
 from .checksum import calculate_checksum
+from .config import get_integration_account_id
 from .logger import log_warn
 from .models import (
     Edge,
@@ -12,7 +13,6 @@ from .models import (
     SourceNode,
     StateApiModel,
 )
-from .config import get_integration_account_id
 from .utils import load_json
 
 

--- a/src/orchestra_dbt/dag.py
+++ b/src/orchestra_dbt/dag.py
@@ -12,7 +12,8 @@ from .models import (
     SourceNode,
     StateApiModel,
 )
-from .utils import get_integration_account_id_from_env, load_json
+from .config import get_integration_account_id
+from .utils import load_json
 
 
 def calculate_freshness_on_node(
@@ -62,7 +63,7 @@ def construct_dag(
     edges: list[Edge] = []
 
     project_name_from_manifest = manifest["metadata"]["project_name"]
-    integration_account_id = get_integration_account_id_from_env()
+    integration_account_id = get_integration_account_id()
     if not integration_account_id:
         log_warn(
             "No integration account ID found. Will use node ID as the asset external ID."

--- a/src/orchestra_dbt/logger.py
+++ b/src/orchestra_dbt/logger.py
@@ -1,8 +1,8 @@
-import os
 from datetime import datetime
 
 import click
 
+from .config import load_orchestra_dbt_settings
 from .constants import SERVICE_NAME
 from .models import MaterialisationNode
 
@@ -16,7 +16,7 @@ def _log(msg: str, fg: str | None, error: bool = False) -> None:
 
 
 def log_debug(msg) -> None:
-    if os.getenv("ORCHESTRA_DBT_DEBUG"):
+    if load_orchestra_dbt_settings().debug:
         _log(msg, None)
 
 

--- a/src/orchestra_dbt/state.py
+++ b/src/orchestra_dbt/state.py
@@ -9,7 +9,11 @@ from typing import cast
 import httpx
 from pydantic import ValidationError
 
-from .config import effective_state_file_path
+from .config import (
+    effective_state_file_path,
+    get_integration_account_id,
+    load_orchestra_dbt_settings,
+)
 from .logger import log_error, log_info, log_warn
 from .models import (
     MaterialisationNode,
@@ -19,7 +23,7 @@ from .models import (
     StateApiModel,
     StateItem,
 )
-from .utils import get_integration_account_id_from_env, load_json
+from .utils import load_json
 
 
 class StateLoadError(Exception):
@@ -31,7 +35,8 @@ class StateSaveError(Exception):
 
 
 def _get_base_api_url() -> str:
-    return f"https://{os.getenv('ORCHESTRA_ENV', 'app').lower()}.getorchestra.io/api/engine/public"
+    env_name = load_orchestra_dbt_settings().orchestra_env
+    return f"https://{env_name}.getorchestra.io/api/engine/public"
 
 
 def _get_headers() -> dict:
@@ -41,7 +46,7 @@ def _get_headers() -> dict:
 
 
 def _apply_integration_account_filter(state: StateApiModel) -> None:
-    if integration_account_id := get_integration_account_id_from_env():
+    if integration_account_id := get_integration_account_id():
         for key in list(state.state):
             if not key.startswith(integration_account_id):
                 state.state.pop(key)

--- a/src/orchestra_dbt/utils.py
+++ b/src/orchestra_dbt/utils.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import yaml
 
@@ -22,7 +21,3 @@ def save_yaml(path: str, data: dict) -> None:
 def load_seed_bytes(path: str) -> bytes:
     with open(path, "rb") as f:
         return f.read()
-
-
-def get_integration_account_id_from_env() -> str | None:
-    return os.getenv("ORCHESTRA_INTEGRATION_ACCOUNT_ID")

--- a/tests/integration/test_local.py
+++ b/tests/integration/test_local.py
@@ -16,8 +16,8 @@ from src.orchestra_dbt.models import (
 from src.orchestra_dbt.sao import calculate_nodes_to_run
 
 
-@patch("src.orchestra_dbt.dag.get_integration_account_id_from_env")
-def test_e2e(mock_get_integration_account_id_from_env):
+@patch("src.orchestra_dbt.dag.get_integration_account_id")
+def test_e2e(mock_get_integration_account_id):
     try:
         local_state = open("local_state.json", "r").read()
     except FileNotFoundError:
@@ -28,7 +28,7 @@ def test_e2e(mock_get_integration_account_id_from_env):
     except FileNotFoundError:
         pytest.skip("local_manifest.json not found")
 
-    mock_get_integration_account_id_from_env.return_value = "TO_BE_COMPLETED"
+    mock_get_integration_account_id.return_value = "TO_BE_COMPLETED"
 
     parsed_dag = construct_dag(
         source_freshness=SourceFreshness(sources={}),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,23 @@ from pathlib import Path
 
 import pytest
 
-from src.orchestra_dbt.config import effective_state_file_path, find_pyproject_directory
+from src.orchestra_dbt.config import (
+    effective_state_file_path,
+    find_pyproject_directory,
+    get_integration_account_id,
+    load_orchestra_dbt_settings,
+)
+
+
+def _clear_orchestra_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "ORCHESTRA_ENV",
+        "ORCHESTRA_USE_STATEFUL",
+        "ORCHESTRA_LOCAL_RUN",
+        "ORCHESTRA_DBT_DEBUG",
+        "ORCHESTRA_INTEGRATION_ACCOUNT_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 def test_effective_state_file_path_env_overrides_pyproject(
@@ -76,3 +92,86 @@ def test_effective_state_file_path_api_key_prefers_http_over_env_and_pyproject(
     monkeypatch.setenv("ORCHESTRA_API_KEY", "secret")
     monkeypatch.setenv("ORCHESTRA_STATE_FILE", str(other))
     assert effective_state_file_path() is None
+
+
+def test_load_orchestra_dbt_settings_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+    _clear_orchestra_settings_env(monkeypatch)
+    settings = load_orchestra_dbt_settings()
+    assert settings.use_stateful is False
+    assert settings.orchestra_env == "app"
+    assert settings.local_run is False
+    assert settings.debug is False
+    assert settings.integration_account_id is None
+
+
+def test_load_orchestra_dbt_settings_from_pyproject(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """[tool.orchestra_dbt]
+use_stateful = true
+orchestra_env = "stage"
+local_run = true
+debug = true
+integration_account_id = "acct-from-toml"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+    _clear_orchestra_settings_env(monkeypatch)
+    settings = load_orchestra_dbt_settings()
+    assert settings.use_stateful is True
+    assert settings.orchestra_env == "stage"
+    assert settings.local_run is True
+    assert settings.debug is True
+    assert settings.integration_account_id == "acct-from-toml"
+    assert get_integration_account_id() == "acct-from-toml"
+
+
+def test_load_orchestra_dbt_settings_env_overrides_pyproject(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.orchestra_dbt]\nuse_stateful = true\norchestra_env = "stage"\n'
+        'integration_account_id = "from-toml"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ORCHESTRA_USE_STATEFUL", "false")
+    monkeypatch.setenv("ORCHESTRA_ENV", "dev")
+    monkeypatch.setenv("ORCHESTRA_INTEGRATION_ACCOUNT_ID", "from-env")
+    settings = load_orchestra_dbt_settings()
+    assert settings.use_stateful is False
+    assert settings.orchestra_env == "dev"
+    assert settings.integration_account_id == "from-env"
+
+
+def test_load_orchestra_dbt_settings_invalid_orchestra_env_in_pyproject(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.orchestra_dbt]\norchestra_env = "invalid"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    _clear_orchestra_settings_env(monkeypatch)
+    with pytest.raises(ValueError, match="Invalid"):
+        load_orchestra_dbt_settings()
+
+
+def test_load_orchestra_dbt_settings_invalid_orchestra_env_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.orchestra_dbt]\norchestra_env = "dev"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ORCHESTRA_ENV", "invalid")
+    with pytest.raises(ValueError, match="Invalid"):
+        load_orchestra_dbt_settings()

--- a/tests/unit/test_dag.py
+++ b/tests/unit/test_dag.py
@@ -114,11 +114,11 @@ class TestCalculateFreshnessOnNode:
 
 class TestConstructDag:
     @patch("src.orchestra_dbt.dag.load_json")
-    @patch("src.orchestra_dbt.dag.get_integration_account_id_from_env")
+    @patch("src.orchestra_dbt.dag.get_integration_account_id")
     def test_construct_dag_with_sources(
-        self, mock_get_integration_account_id_from_env, mock_load_json, sample_manifest
+        self, mock_get_integration_account_id, mock_load_json, sample_manifest
     ):
-        mock_get_integration_account_id_from_env.return_value = "integration_account_id"
+        mock_get_integration_account_id.return_value = "integration_account_id"
         mock_load_json.return_value = sample_manifest
 
         source_freshness = SourceFreshness(

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -26,14 +26,14 @@ from src.orchestra_dbt.state import (
 
 
 class TestLoadState:
-    @patch("src.orchestra_dbt.state.get_integration_account_id_from_env")
+    @patch("src.orchestra_dbt.state.get_integration_account_id")
     @pytest.mark.parametrize(
         "integration_account_id, expected_state_len",
         [(None, 3), ("a", 1), ("b", 1)],
     )
     def test_load_state_success(
         self,
-        mock_get_integration_account_id_from_env,
+        mock_get_integration_account_id,
         httpx_mock: HTTPXMock,
         integration_account_id: str | None,
         expected_state_len: int,
@@ -71,7 +71,7 @@ class TestLoadState:
             },
         )
 
-        mock_get_integration_account_id_from_env.return_value = integration_account_id
+        mock_get_integration_account_id.return_value = integration_account_id
         loaded_state = load_state()
         assert len(loaded_state.state) == expected_state_len
         assert list(loaded_state.state.values())[0] == StateItem(

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -8,7 +8,7 @@ This folder is a minimal [dbt Core](https://www.getdbt.com/) project that works 
 - **Staging → intermediate → marts** show a small DAG; the mart [`mart_daily_totals`](dbt/models/marts/mart_daily_totals.sql) sets **`freshness.build_after`** so Orchestra can reason about when downstream models should run relative to upstream updates (see [dbt Core state management](https://docs.getorchestra.io/docs/guides/dbt-core-state-management/guide)).
 - **Macros** ([`dbt/macros/audit_run_id.sql`](dbt/macros/audit_run_id.sql)) and **snapshots** ([`dbt/snapshots/snap_mart_daily_totals.sql`](dbt/snapshots/snap_mart_daily_totals.sql)) mirror common real projects without extra packages.
 
-Orchestra’s CLI wrapper (`orchestra-dbt`) reads manifest and state from the platform when `ORCHESTRA_USE_STATEFUL=true`. See the repo root [README](../README.md) for local env vars.
+Orchestra’s CLI wrapper (`orchestra-dbt`) reads manifest and state from the platform when stateful orchestration is enabled (`use_stateful` in `[tool.orchestra_dbt]` or `ORCHESTRA_USE_STATEFUL=true`). See the repo root [README](../README.md) for configuration and env overrides.
 
 ## Local run (Postgres)
 

--- a/tutorial/dbt/pyproject.toml
+++ b/tutorial/dbt/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.0.1"
 requires-python = ">=3.11"
 dependencies = ["dbt-core", "dbt-postgres", "dbt-snowflake"]
 
-# To be enabled when ordering of state preference updated in a separate PR.
+# Optional: configure orchestra-dbt without exporting many env vars (see repo README).
 # [tool.orchestra_dbt]
+# use_stateful = true
+# orchestra_env = "dev"
 # state_file = ".orchestra/dbt_state.json"
+# local_run = true


### PR DESCRIPTION
## Objective
Let projects configure orchestra-dbt via `pyproject.toml` with environment variables as overrides.

## Changes
- Add `[tool.orchestra_dbt]` settings model and precedence (env over pyproject over defaults)
- Wire stateful mode, Orchestra environment, local run, debug logging, and integration account id
- Keep `ORCHESTRA_API_KEY` environment-only; document options in the README

## Testing
Unit tested; `pytest` passes.

## Checklist
- [ ] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes


Made with [Cursor](https://cursor.com)