### PR TITLE
Document warehouse support for implicit source freshness (ENG-9769)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Match local checks to CI where practical: `uv run ruff check .`, `uv run basedpy
 
 Orchestra patches dbt’s freshness runner so that when a source has **no** `loaded_at_query` or `loaded_at_field`, adapter-specific logic can still infer `max_loaded_at` (for example Databricks uses `DESCRIBE HISTORY`). That path is keyed by the dbt adapter type string from `FreshnessRunner.adapter.type()` (for example `"databricks"`).
 
-End-user expectations by warehouse are summarized in the root **`README.md`** (section *Warehouse adapters and implicit source freshness*): Databricks has the `DESCRIBE HISTORY` fallback; Snowflake, Fabric, and Postgres rely on standard dbt freshness with `loaded_at_*` configured; DuckDB does not support implicit freshness without those fields.
+End-user expectations by warehouse are summarized in the root **`README.md`** (section *Warehouse adapters and implicit source freshness*): Databricks has the `DESCRIBE HISTORY` fallback; Snowflake, Fabric, and Postgres rely on standard dbt freshness with `loaded_at_*` configured; DuckDB does not support this current form of state aware orchestration.
 
 To add a warehouse:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Match local checks to CI where practical: `uv run ruff check .`, `uv run basedpy
 
 Orchestra patches dbt’s freshness runner so that when a source has **no** `loaded_at_query` or `loaded_at_field`, adapter-specific logic can still infer `max_loaded_at` (for example Databricks uses `DESCRIBE HISTORY`). That path is keyed by the dbt adapter type string from `FreshnessRunner.adapter.type()` (for example `"databricks"`).
 
+End-user expectations by warehouse are summarized in the root **`README.md`** (section *Warehouse adapters and implicit source freshness*): Databricks has the `DESCRIBE HISTORY` fallback; Snowflake, Fabric, and Postgres rely on standard dbt freshness with `loaded_at_*` configured; DuckDB does not support implicit freshness without those fields.
+
 To add a warehouse:
 
 1. Implement a handler in `src/orchestra_dbt/source_freshness/fallbacks/`, for example `try_snowflake_fallback(runner, compiled_node, manifest)`, that returns a dbt `SourceFreshnessResult` or `None` if the fallback does not apply or fails.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ For S3, install the optional dependency (`pip install 'orchestra-dbt[s3]'` or `u
 
 Stateful orchestration only runs for `dbt build`, `dbt run`, and `dbt test`. Other dbt subcommands are passed through to dbt unchanged.
 
+### Warehouse adapters and implicit source freshness
+
+Stateful reuse uses `dbt source freshness` results. When a source defines **`loaded_at_field`** or **`loaded_at_query`**, dbt’s normal freshness logic runs on every adapter Orchestra supports through dbt Core.
+
+When **both** are omitted, Orchestra can still run **adapter-specific** SQL to infer `max_loaded_at` (see `src/orchestra_dbt/source_freshness/`). Only the adapters below register that path today; the mapping is keyed by `FreshnessRunner.adapter.type()`.
+
+| Warehouse | dbt adapter type (typical) | Implicit freshness (no `loaded_at_*`) |
+| --- | --- | --- |
+| **Databricks** | `databricks` | **Supported** — uses `DESCRIBE HISTORY` on the source relation. |
+| **Snowflake** | `snowflake` | **Use `loaded_at_field` or `loaded_at_query`** — no Orchestra fallback; standard dbt freshness. |
+| **Microsoft Fabric** | `fabric` | Same as Snowflake — configure `loaded_at_*`; no Orchestra fallback. |
+| **PostgreSQL** | `postgres` | Same as Snowflake — configure `loaded_at_*`; no Orchestra fallback. |
+| **DuckDB** | `duckdb` | **Not supported for implicit freshness** — without `loaded_at_*`, do not rely on inferred `max_loaded_at`; set `loaded_at_field` or `loaded_at_query` if you need freshness-driven reuse. |
+| **Other adapters** | varies | No Orchestra fallback unless listed above; use `loaded_at_*` or verify dbt’s default behavior for your warehouse. |
+
+For adapters without a registered fallback, if both `loaded_at` settings are missing, Orchestra follows dbt’s `FreshnessRunner` behavior (which may surface as warnings or a non-actionable result depending on dbt and the warehouse).
+
 ### Runtime behavior by command and mode
 
 | Stateful enabled | dbt command | Behavior |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When **both** are omitted, Orchestra can still run **adapter-specific** SQL to i
 | **Snowflake** | `snowflake` | **Use `loaded_at_field` or `loaded_at_query`** — no Orchestra fallback; standard dbt freshness. |
 | **Microsoft Fabric** | `fabric` | Same as Snowflake — configure `loaded_at_*`; no Orchestra fallback. |
 | **PostgreSQL** | `postgres` | Same as Snowflake — configure `loaded_at_*`; no Orchestra fallback. |
-| **DuckDB** | `duckdb` | **Not supported for implicit freshness** — without `loaded_at_*`, do not rely on inferred `max_loaded_at`; set `loaded_at_field` or `loaded_at_query` if you need freshness-driven reuse. |
+| **DuckDB** | `duckdb` | **Not supported** |
 | **Other adapters** | varies | No Orchestra fallback unless listed above; use `loaded_at_*` or verify dbt’s default behavior for your warehouse. |
 
 For adapters without a registered fallback, if both `loaded_at` settings are missing, Orchestra follows dbt’s `FreshnessRunner` behavior (which may surface as warnings or a non-actionable result depending on dbt and the warehouse).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Make warehouse behavior for implicit source freshness explicit for users and contributors.

## Changes
- Added a README section that lists Databricks, Snowflake, Fabric, Postgres, DuckDB, and other adapters with how implicit freshness works.
- Linked CONTRIBUTING to that section so the adapter-extension guide stays aligned with product docs.

## Testing
Documentation-only change; no automated tests run.

## Checklist
- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11959996-4479-464f-aefd-ea4483aca38c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11959996-4479-464f-aefd-ea4483aca38c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

