### PR TITLE
Default local_run to true (ENG-9757)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- `local_run` now defaults to `true` when not set in `[tool.orchestra_dbt]` or environment.
-
-## [0.4.0] - 2026-04-22
+## [1.0.0] - 2026-04-XX
 
 First formal release of this codebase.
 
-[0.4.0]: https://github.com/orchestra-hq/sao-paolo/releases/tag/v0.4.0
+[1.0.0]: https://github.com/orchestra-hq/sao-paolo/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `local_run` now defaults to `true` when not set in `[tool.orchestra_dbt]` or environment.
+
 ## [0.4.0] - 2026-04-22
 
 First formal release of this codebase.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For non-secret options, **if an environment variable is set, it overrides** valu
 | `state_file` | string (optional) | — | Local JSON path or `s3://bucket/key` for state (see backend table below). |
 | `use_stateful` | bool | `false` | Turn on stateful orchestration for supported dbt commands. |
 | `orchestra_env` | string | `app` | Orchestra deployment: `app`, `stage`, or `dev` (HTTP API host). |
-| `local_run` | bool | `false` | After reuse, revert patched files (typical for local iteration). |
+| `local_run` | bool | `true` | After reuse, revert patched files (typical for local iteration). |
 | `debug` | bool | `false` | Verbose `orchestra-dbt` debug logging. |
 | `integration_account_id` | string (optional) | — | When set, filter state keys to this integration account prefix. |
 

--- a/src/orchestra_dbt/asset_external_id.py
+++ b/src/orchestra_dbt/asset_external_id.py
@@ -5,7 +5,7 @@ def generate_asset_external_id(
     node_id: str,
     relation_name: str | None,
     integration_account_id: str | None,
-    local_run: bool = False,
+    local_run: bool = True,
 ) -> str:
     """
     Generate a stable external ID used for Orchestra state keys.

--- a/src/orchestra_dbt/config.py
+++ b/src/orchestra_dbt/config.py
@@ -18,7 +18,7 @@ class OrchestraDbtSettings(BaseModel):
     state_file: str | None = None
     use_stateful: bool = False
     orchestra_env: Literal["app", "stage", "dev"] = "app"
-    local_run: bool = False
+    local_run: bool = True
     debug: bool = False
     integration_account_id: str | None = None
 

--- a/tests/integration/test_local.py
+++ b/tests/integration/test_local.py
@@ -31,7 +31,10 @@ def test_e2e(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         dag_module,
         "load_orchestra_dbt_settings",
-        lambda: OrchestraDbtSettings(integration_account_id="TO_BE_COMPLETED"),
+        lambda: OrchestraDbtSettings(
+            integration_account_id="TO_BE_COMPLETED",
+            local_run=False,
+        ),
     )
 
     parsed_dag = construct_dag(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -152,7 +152,7 @@ def test_load_orchestra_dbt_settings_defaults(
     settings = load_orchestra_dbt_settings()
     assert settings.use_stateful is False
     assert settings.orchestra_env == "app"
-    assert settings.local_run is False
+    assert settings.local_run is True
     assert settings.debug is False
     assert settings.integration_account_id is None
 

--- a/tests/unit/test_dag.py
+++ b/tests/unit/test_dag.py
@@ -124,7 +124,8 @@ class TestConstructDag:
             dag_module,
             "load_orchestra_dbt_settings",
             lambda: OrchestraDbtSettings(
-                integration_account_id="integration_account_id"
+                integration_account_id="integration_account_id",
+                local_run=False,
             ),
         )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective

Default `local_run` to true so local iteration matches typical use without extra config.

## Changes

- Default `local_run` to true in Orchestra settings and the asset external ID helper
- Document the new default and record it in the changelog
- Keep DAG tests and the optional local integration harness on explicit `local_run=false` where prefixed state keys are required

## Testing

Unit tests and Ruff checks were run locally and passed.

## Checklist

- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes

---

# Summary

Implements ENG-9757: `local_run` is now `true` by default when not set in `pyproject.toml` or environment. Set `local_run = false` or `ORCHESTRA_LOCAL_RUN=false` for Orchestra-hosted runs that need integration-prefixed asset external IDs and state keys.

## How to test

```bash
uv run pytest
uv run ruff check . && uv run ruff format --check . && uv run basedpyright
```

## Checklist

- [x] Tests added or updated where behaviour changed
- [x] Unit tests and linting pass locally
- [x] Documentation updated where necessary
- [x] Changelog updated for user-visible changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f16447b5-3e3a-42c6-91dc-7f7118b39775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f16447b5-3e3a-42c6-91dc-7f7118b39775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

