### PR TITLE
ENG-9770: Optional seed state orchestration

### DIFF
--- a/src/orchestra_dbt/config.py
+++ b/src/orchestra_dbt/config.py
@@ -21,6 +21,7 @@ class OrchestraDbtSettings(BaseModel):
     local_run: bool = False
     debug: bool = False
     integration_account_id: str | None = None
+    seed_state_orchestration: bool = False
 
     @field_validator("orchestra_env", mode="before")
     @classmethod
@@ -71,6 +72,12 @@ def _merge_env_overrides(settings: OrchestraDbtSettings) -> OrchestraDbtSettings
     integration = _env_str("ORCHESTRA_INTEGRATION_ACCOUNT_ID")
     if integration is not None:
         settings = settings.model_copy(update={"integration_account_id": integration})
+
+    seed_state = _env_bool("ORCHESTRA_SEED_STATE_ORCHESTRATION")
+    if seed_state is not None:
+        settings = settings.model_copy(
+            update={"seed_state_orchestration": seed_state}
+        )
 
     return OrchestraDbtSettings.model_validate(settings.model_dump())
 

--- a/src/orchestra_dbt/dag.py
+++ b/src/orchestra_dbt/dag.py
@@ -25,6 +25,8 @@ def calculate_freshness_on_node(
     track_state: bool,
     from_external_package: bool,
     depends_on_nodes: list[str] | None,
+    *,
+    seed_state_orchestration: bool = False,
 ) -> tuple[Freshness, str]:
     if resource_type == "snapshot":
         # Note: currently, we always run snapshots. Need to configure how to propagate
@@ -40,7 +42,7 @@ def calculate_freshness_on_node(
             "Model from external package without parent dependencies - skipping state orchestration.",
         )
 
-    if resource_type == "seed":
+    if resource_type == "seed" and not seed_state_orchestration:
         return Freshness.DIRTY, "State orchestration for seeds currently disabled."
 
     if asset_external_id not in state.state:
@@ -119,6 +121,7 @@ def construct_dag(
                     track_state,
                     from_external_package,
                     depends_on_nodes,
+                    seed_state_orchestration=settings.seed_state_orchestration,
                 )
 
                 nodes[node_id] = MaterialisationNode(

--- a/src/orchestra_dbt/dag.py
+++ b/src/orchestra_dbt/dag.py
@@ -25,7 +25,6 @@ def calculate_freshness_on_node(
     track_state: bool,
     from_external_package: bool,
     depends_on_nodes: list[str] | None,
-    *,
     seed_state_orchestration: bool = False,
 ) -> tuple[Freshness, str]:
     if resource_type == "snapshot":
@@ -121,7 +120,7 @@ def construct_dag(
                     track_state,
                     from_external_package,
                     depends_on_nodes,
-                    seed_state_orchestration=settings.seed_state_orchestration,
+                    settings.seed_state_orchestration,
                 )
 
                 nodes[node_id] = MaterialisationNode(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -40,6 +40,7 @@ def _clear_orchestra_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "ORCHESTRA_LOCAL_RUN",
         "ORCHESTRA_DBT_DEBUG",
         "ORCHESTRA_INTEGRATION_ACCOUNT_ID",
+        "ORCHESTRA_SEED_STATE_ORCHESTRATION",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -155,6 +156,7 @@ def test_load_orchestra_dbt_settings_defaults(
     assert settings.local_run is False
     assert settings.debug is False
     assert settings.integration_account_id is None
+    assert settings.seed_state_orchestration is False
 
 
 def test_load_orchestra_dbt_settings_from_pyproject(
@@ -167,6 +169,7 @@ orchestra_env = "stage"
 local_run = true
 debug = true
 integration_account_id = "acct-from-toml"
+seed_state_orchestration = true
 """,
         encoding="utf-8",
     )
@@ -179,6 +182,7 @@ integration_account_id = "acct-from-toml"
     assert settings.local_run is True
     assert settings.debug is True
     assert settings.integration_account_id == "acct-from-toml"
+    assert settings.seed_state_orchestration is True
     assert get_integration_account_id() == "acct-from-toml"
 
 
@@ -187,17 +191,20 @@ def test_load_orchestra_dbt_settings_env_overrides_pyproject(
 ) -> None:
     (tmp_path / "pyproject.toml").write_text(
         '[tool.orchestra_dbt]\nuse_stateful = true\norchestra_env = "stage"\n'
-        'integration_account_id = "from-toml"\n',
+        'integration_account_id = "from-toml"\n'
+        "seed_state_orchestration = false\n",
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("ORCHESTRA_USE_STATEFUL", "false")
     monkeypatch.setenv("ORCHESTRA_ENV", "dev")
     monkeypatch.setenv("ORCHESTRA_INTEGRATION_ACCOUNT_ID", "from-env")
+    monkeypatch.setenv("ORCHESTRA_SEED_STATE_ORCHESTRATION", "true")
     settings = load_orchestra_dbt_settings()
     assert settings.use_stateful is False
     assert settings.orchestra_env == "dev"
     assert settings.integration_account_id == "from-env"
+    assert settings.seed_state_orchestration is True
 
 
 def test_load_orchestra_dbt_settings_invalid_orchestra_env_in_pyproject(

--- a/tests/unit/test_dag.py
+++ b/tests/unit/test_dag.py
@@ -28,6 +28,7 @@ class TestCalculateFreshnessOnNode:
             track_state=True,
             from_external_package=False,
             depends_on_nodes=[],
+            seed_state_orchestration=False,
         ) == (Freshness.DIRTY, "Snapshot is always dirty.")
 
     def test_calculate_freshness_on_node_not_tracking_state(self):
@@ -39,7 +40,55 @@ class TestCalculateFreshnessOnNode:
             track_state=False,
             from_external_package=False,
             depends_on_nodes=[],
+            seed_state_orchestration=False,
         ) == (Freshness.DIRTY, "State orchestration for this node is disabled.")
+
+    def test_calculate_freshness_on_node_seed_disabled(self):
+        assert calculate_freshness_on_node(
+            asset_external_id="test.seed.a.b",
+            checksum="123",
+            state=StateApiModel(state={}),
+            resource_type="seed",
+            track_state=True,
+            from_external_package=False,
+            depends_on_nodes=[],
+            seed_state_orchestration=False,
+        ) == (
+            Freshness.DIRTY,
+            "State orchestration for seeds currently disabled.",
+        )
+
+    def test_calculate_freshness_on_node_seed_enabled_not_in_state(self):
+        assert calculate_freshness_on_node(
+            asset_external_id="test.seed.a.b",
+            checksum="123",
+            state=StateApiModel(state={}),
+            resource_type="seed",
+            track_state=True,
+            from_external_package=False,
+            depends_on_nodes=[],
+            seed_state_orchestration=True,
+        ) == (Freshness.DIRTY, "Seed not previously seen in state.")
+
+    def test_calculate_freshness_on_node_seed_enabled_clean(self):
+        assert calculate_freshness_on_node(
+            asset_external_id="test.seed.a.b",
+            checksum="123",
+            state=StateApiModel(
+                state={
+                    "test.seed.a.b": StateItem(
+                        last_updated=datetime(2024, 1, 1, 12, 0, 0),
+                        checksum="123",
+                        sources={},
+                    ),
+                }
+            ),
+            resource_type="seed",
+            track_state=True,
+            from_external_package=False,
+            depends_on_nodes=[],
+            seed_state_orchestration=True,
+        ) == (Freshness.CLEAN, "Seed in same state as last run.")
 
     def test_calculate_freshness_on_node_not_in_state(self):
         assert calculate_freshness_on_node(
@@ -50,6 +99,7 @@ class TestCalculateFreshnessOnNode:
             track_state=True,
             from_external_package=False,
             depends_on_nodes=[],
+            seed_state_orchestration=False,
         ) == (Freshness.DIRTY, "Model not previously seen in state.")
 
     def test_calculate_freshness_on_node_checksum_changed(self):
@@ -69,6 +119,7 @@ class TestCalculateFreshnessOnNode:
             track_state=True,
             from_external_package=False,
             depends_on_nodes=[],
+            seed_state_orchestration=False,
         ) == (Freshness.DIRTY, "Checksum changed since last run.")
 
     def test_calculate_freshness_on_node_checksum_matches(self):
@@ -88,6 +139,7 @@ class TestCalculateFreshnessOnNode:
             track_state=True,
             from_external_package=False,
             depends_on_nodes=[],
+            seed_state_orchestration=False,
         ) == (Freshness.CLEAN, "Model in same state as last run.")
 
     def test_calculate_freshness_on_model_from_external_package_without_dependencies(
@@ -109,6 +161,7 @@ class TestCalculateFreshnessOnNode:
             track_state=True,
             from_external_package=True,
             depends_on_nodes=[],
+            seed_state_orchestration=False,
         ) == (
             Freshness.DIRTY,
             "Model from external package without parent dependencies - skipping state orchestration.",
@@ -241,3 +294,83 @@ class TestConstructDag:
         # Model should be DIRTY since checksum doesn't match
         assert isinstance(dag.nodes["model.test_project.model_a"], MaterialisationNode)
         assert dag.nodes["model.test_project.model_a"].freshness == Freshness.DIRTY
+
+    def test_construct_dag_seed_state_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest = {
+            "metadata": {"project_name": "test_project"},
+            "nodes": {
+                "seed.test_project.my_seed": {
+                    "resource_type": "seed",
+                    "checksum": {"checksum": "abc"},
+                    "config": {},
+                    "package_name": "test_project",
+                    "original_file_path": "seeds/my_seed.csv",
+                    "relation_name": "my_seed",
+                    "depends_on": {"nodes": []},
+                },
+            },
+            "child_map": {},
+        }
+        monkeypatch.setattr(dag_module, "load_json", lambda _: manifest)
+        monkeypatch.setattr(dag_module, "calculate_checksum", lambda *a, **k: "stable")
+        monkeypatch.setattr(
+            dag_module,
+            "load_orchestra_dbt_settings",
+            lambda: OrchestraDbtSettings(
+                integration_account_id="acct",
+                seed_state_orchestration=False,
+            ),
+        )
+
+        dag = construct_dag(SourceFreshness(sources={}), StateApiModel(state={}))
+        node = dag.nodes["seed.test_project.my_seed"]
+        assert isinstance(node, MaterialisationNode)
+        assert node.freshness == Freshness.DIRTY
+        assert node.reason == "State orchestration for seeds currently disabled."
+
+    def test_construct_dag_seed_state_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest = {
+            "metadata": {"project_name": "test_project"},
+            "nodes": {
+                "seed.test_project.my_seed": {
+                    "resource_type": "seed",
+                    "checksum": {"checksum": "abc"},
+                    "config": {},
+                    "package_name": "test_project",
+                    "original_file_path": "seeds/my_seed.csv",
+                    "relation_name": "my_seed",
+                    "depends_on": {"nodes": []},
+                },
+            },
+            "child_map": {},
+        }
+        monkeypatch.setattr(dag_module, "load_json", lambda _: manifest)
+        monkeypatch.setattr(dag_module, "calculate_checksum", lambda *a, **k: "stable")
+        monkeypatch.setattr(
+            dag_module,
+            "load_orchestra_dbt_settings",
+            lambda: OrchestraDbtSettings(
+                integration_account_id="acct",
+                seed_state_orchestration=True,
+            ),
+        )
+        asset_id = "acct.my_seed"
+        state = StateApiModel(
+            state={
+                asset_id: StateItem(
+                    last_updated=datetime(2024, 1, 1, 12, 0, 0),
+                    checksum="stable",
+                    sources={},
+                ),
+            }
+        )
+
+        dag = construct_dag(SourceFreshness(sources={}), state)
+        node = dag.nodes["seed.test_project.my_seed"]
+        assert isinstance(node, MaterialisationNode)
+        assert node.freshness == Freshness.CLEAN
+        assert node.reason == "Seed in same state as last run."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective

Let operators opt in to state-aware freshness for dbt seeds.

## Changes

- Added pyproject and environment configuration for seed state orchestration.
- Seeds respect the same state and checksum flow as other materialisations when the option is enabled.
- Extended unit tests for settings, freshness calculation, and DAG construction.

## Testing

Unit tests and static checks were run locally for the touched modules.

## Checklist

- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ce2ec47-3f96-4bf4-b398-6ac9df287c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce2ec47-3f96-4bf4-b398-6ac9df287c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

