### PR TITLE
[ENG-9739] Reference CI pipeline from this repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,6 @@ jobs:
           ORCHESTRA_API_KEY: ""
         run: uv run pytest tests/integration/test_tutorial_dbt.py -sv
 
-  # Move YAML to this repo and reference.
   orchestra:
     runs-on: ubuntu-latest
     needs: [ test, tutorial-dbt ]

--- a/tutorial/pipeline.yaml
+++ b/tutorial/pipeline.yaml
@@ -7,7 +7,7 @@ pipeline:
         integration: DBT_CORE
         integration_job: DBT_CORE_EXECUTE
         parameters:
-          commands: dbt build
+          commands: dbt build --target dev
           package_manager: UV
           python_version: "3.12"
           use_state_orchestration: true
@@ -19,6 +19,7 @@ pipeline:
             \ }}\"\n}"
         depends_on: []
         name: CI Smoke Test Execution
+        connection: sao_test_56256
     depends_on: []
     name: CI Smoke Test Task Group
 webhook:


### PR DESCRIPTION
# Summary

Makes the CI pipeline reference from the repo directly.

Changed the pipeline ID in the secrets.

Test is making sure CI runs correctly using the new pipeline ID.
