### PR TITLE
feat: add GCS state backend using Application Default Credentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ Security = "https://github.com/orchestra-hq/sao-paolo/security/policy"
 dev = [
     "basedpyright",
     "boto3",
+    "cloud-storage-mocker",
     "dbt-core>=1.10,<1.12",
     "moto[s3]",
     "pytest-httpx",
@@ -48,6 +49,9 @@ debug = ["awscrt", "boto3", "graphviz"]
 
 # S3-backed state (optional; boto3 loaded only when S3 URI is configured)
 s3 = ["boto3"]
+
+# GCS-backed state (optional; google-cloud-storage loaded only when GCS URI is configured)
+gcs = ["google-cloud-storage"]
 
 [project.scripts]
 orc = "orchestra_dbt.cli:main"

--- a/src/orchestra_dbt/state_backends/factory.py
+++ b/src/orchestra_dbt/state_backends/factory.py
@@ -60,3 +60,11 @@ def resolved_state_backend(cwd: Path | None = None) -> StateBackend:
                     "State backend config is S3 but s3_bucket or s3_key is missing"
                 )
             return S3StateBackend(cfg.s3_bucket, cfg.s3_key)
+        case StateBackendKind.GCS:
+            from .gcs import GCSStateBackend
+
+            if cfg.gcs_bucket is None or cfg.gcs_key is None:
+                raise RuntimeError(
+                    "State backend config is GCS but gcs_bucket or gcs_key is missing"
+                )
+            return GCSStateBackend(cfg.gcs_bucket, cfg.gcs_key)

--- a/src/orchestra_dbt/state_backends/gcs.py
+++ b/src/orchestra_dbt/state_backends/gcs.py
@@ -33,6 +33,15 @@ class GCSStateBackend:
             blob = client.bucket(bucket).blob(key)
             raw = blob.download_as_text(encoding="utf-8")
         except NotFound:
+            # Distinguish missing blob (expected on first run) from missing bucket
+            # (config error). Both return 404 from the GCS API, so verify the bucket
+            # exists before treating this as an empty-state case.
+            try:
+                client.get_bucket(bucket)
+            except NotFound as bucket_err:
+                raise StateLoadError(
+                    f"GCS bucket 'gs://{bucket}' does not exist: {bucket_err}"
+                ) from bucket_err
             log_info(
                 f"No state object at gs://{bucket}/{key}; starting with empty state."
             )

--- a/src/orchestra_dbt/state_backends/gcs.py
+++ b/src/orchestra_dbt/state_backends/gcs.py
@@ -42,6 +42,15 @@ class GCSStateBackend:
                 raise StateLoadError(
                     f"GCS bucket 'gs://{bucket}' does not exist: {bucket_err}"
                 ) from bucket_err
+            except (Forbidden, Unauthorized) as e:
+                raise StateLoadError(
+                    f"Permission denied reading gs://{bucket}/{key}. "
+                    f"Ensure the service account has storage.objects.get permission: {e}"
+                ) from e
+            except Exception as e:
+                raise StateLoadError(
+                    f"Failed to load state from gs://{bucket}/{key}: {e}"
+                ) from e
             log_info(
                 f"No state object at gs://{bucket}/{key}; starting with empty state."
             )

--- a/src/orchestra_dbt/state_backends/gcs.py
+++ b/src/orchestra_dbt/state_backends/gcs.py
@@ -1,0 +1,94 @@
+import json
+
+from google.api_core.exceptions import Forbidden, NotFound, Unauthorized
+from google.auth.exceptions import DefaultCredentialsError
+from google.cloud import storage
+from pydantic import ValidationError
+
+from ..logger import log_info
+from ..models import StateApiModel
+from ..state_errors import StateLoadError, StateSaveError
+from ..state_filters import apply_integration_account_filter
+from .logging import log_state_loaded, log_state_saved
+
+
+class GCSStateBackend:
+    def __init__(self, bucket: str, key: str) -> None:
+        self._bucket = bucket
+        self._key = key
+
+    def load(self) -> StateApiModel:
+        bucket, key = self._bucket, self._key
+
+        try:
+            client = storage.Client()
+        except DefaultCredentialsError as e:
+            raise StateLoadError(
+                f"GCS credentials not found. Configure Application Default Credentials "
+                f"(e.g. `gcloud auth application-default login` or set "
+                f"GOOGLE_APPLICATION_CREDENTIALS). Details: {e}"
+            ) from e
+
+        try:
+            blob = client.bucket(bucket).blob(key)
+            raw = blob.download_as_text(encoding="utf-8")
+        except NotFound:
+            log_info(
+                f"No state object at gs://{bucket}/{key}; starting with empty state."
+            )
+            return StateApiModel(state={})
+        except (Forbidden, Unauthorized) as e:
+            raise StateLoadError(
+                f"Permission denied reading gs://{bucket}/{key}. "
+                f"Ensure the service account has storage.objects.get permission: {e}"
+            ) from e
+        except Exception as e:
+            raise StateLoadError(
+                f"Failed to load state from gs://{bucket}/{key}: {e}"
+            ) from e
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise StateLoadError(
+                f"State object at gs://{bucket}/{key} is not valid JSON: {e}"
+            ) from e
+
+        try:
+            state = StateApiModel.model_validate(data)
+        except (ValidationError, ValueError) as e:
+            raise StateLoadError(
+                f"State object at gs://{bucket}/{key} failed validation: {e}"
+            ) from e
+
+        apply_integration_account_filter(state)
+        log_state_loaded("gcs", state)
+        return state
+
+    def save(self, state: StateApiModel) -> None:
+        bucket, key = self._bucket, self._key
+
+        try:
+            client = storage.Client()
+        except DefaultCredentialsError as e:
+            raise StateSaveError(
+                f"GCS credentials not found. Configure Application Default Credentials "
+                f"(e.g. `gcloud auth application-default login` or set "
+                f"GOOGLE_APPLICATION_CREDENTIALS). Details: {e}"
+            ) from e
+
+        payload = state.model_dump_json(exclude_none=True)
+        try:
+            blob = client.bucket(bucket).blob(key)
+            blob.upload_from_string(payload, content_type="application/json; charset=utf-8")
+        except (Forbidden, Unauthorized) as e:
+            raise StateSaveError(
+                f"Permission denied writing gs://{bucket}/{key}. "
+                f"Ensure the service account has storage.objects.create permission: {e}"
+            ) from e
+        except Exception as e:
+            raise StateSaveError(
+                f"Failed to save state to gs://{bucket}/{key}: {e}"
+            ) from e
+
+        log_state_saved("gcs")

--- a/src/orchestra_dbt/state_backends/logging.py
+++ b/src/orchestra_dbt/state_backends/logging.py
@@ -3,12 +3,13 @@ from typing import Literal
 from ..logger import log_info
 from ..models import StateApiModel
 
-StateBackendLabel = Literal["http", "local_file", "s3"]
+StateBackendLabel = Literal["http", "local_file", "s3", "gcs"]
 
 _LOAD_MESSAGE_LABEL: dict[StateBackendLabel, str] = {
     "http": "Orchestra HTTP",
     "local_file": "local file",
     "s3": "S3",
+    "gcs": "GCS",
 }
 
 
@@ -18,7 +19,7 @@ def log_state_loaded(backend: StateBackendLabel, state: StateApiModel) -> None:
 
 
 def log_state_saved(backend: StateBackendLabel) -> None:
-    if backend == "s3":
-        log_info("State saved to S3")
+    if backend in ("s3", "gcs"):
+        log_info(f"State saved to {_LOAD_MESSAGE_LABEL[backend]}")
     else:
         log_info("State saved")

--- a/src/orchestra_dbt/state_types.py
+++ b/src/orchestra_dbt/state_types.py
@@ -8,6 +8,7 @@ class StateBackendKind(str, Enum):
     HTTP = "http"
     LOCAL_FILE = "local_file"
     S3 = "s3"
+    GCS = "gcs"
 
 
 class StateBackendConfig(BaseModel):
@@ -17,6 +18,8 @@ class StateBackendConfig(BaseModel):
     local_path: Path | None = None
     s3_bucket: str | None = None
     s3_key: str | None = None
+    gcs_bucket: str | None = None
+    gcs_key: str | None = None
 
 
 def parse_s3_uri(uri: str) -> tuple[str, str]:
@@ -37,6 +40,24 @@ def parse_s3_uri(uri: str) -> tuple[str, str]:
     return bucket, key
 
 
+def parse_gcs_uri(uri: str) -> tuple[str, str]:
+    prefix = "gs://"
+    if not uri.lower().startswith(prefix):
+        msg = f"Expected GCS URI starting with {prefix!r}, got: {uri!r}"
+        raise ValueError(msg)
+    rest = uri[len(prefix) :]
+    if "/" not in rest:
+        msg = f"GCS URI must include a key after the bucket: {uri!r}"
+        raise ValueError(msg)
+    bucket, _, key = rest.partition("/")
+    bucket = bucket.strip()
+    key = key.lstrip("/")
+    if not bucket or not key:
+        msg = f"Invalid GCS URI (bucket and key required): {uri!r}"
+        raise ValueError(msg)
+    return bucket, key
+
+
 def backend_config_from_state_location(
     raw: str, resolve_relative_from: Path
 ) -> StateBackendConfig:
@@ -47,6 +68,13 @@ def backend_config_from_state_location(
             kind=StateBackendKind.S3,
             s3_bucket=bucket,
             s3_key=key,
+        )
+    if stripped.lower().startswith("gs://"):
+        bucket, key = parse_gcs_uri(stripped)
+        return StateBackendConfig(
+            kind=StateBackendKind.GCS,
+            gcs_bucket=bucket,
+            gcs_key=key,
         )
     p = Path(stripped).expanduser()
     if p.is_absolute():

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 import boto3
 import httpx
 import pytest
+from cloud_storage_mocker import Mount
+from cloud_storage_mocker import patch as gcs_patch
 from moto import mock_aws
 from pytest_httpx import HTTPXMock
 
@@ -20,6 +22,7 @@ from src.orchestra_dbt.models import (
 )
 from src.orchestra_dbt.state import (
     StateLoadError,
+    StateSaveError,
     _load_run_results,
     load_state,
     save_state,
@@ -864,3 +867,100 @@ class TestSaveStateS3:
         obj = conn.get_object(Bucket="bucket", Key="dir/f.json")
         body = obj["Body"].read()
         assert b'"checksum"' in body
+
+
+class TestLoadStateGCS:
+    def test_load_state_gcs_missing_blob_starts_empty(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+        monkeypatch.setenv("ORCHESTRA_STATE_FILE", "gs://test-bucket/prefix/state.json")
+
+        with gcs_patch(
+            mounts=[Mount("test-bucket", tmp_path / "gcs", readable=True, writable=True)]
+        ):
+            assert load_state() == StateApiModel(state={})
+
+    def test_load_state_gcs_success(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        bucket_dir = tmp_path / "gcs"
+        blob_path = bucket_dir / "k.json"
+        bucket_dir.mkdir()
+        blob_path.write_text(
+            '{"state": {"model.x": {"checksum": "c", '
+            '"last_updated": "2024-01-01T12:00:00", "sources": {}}}}'
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+        monkeypatch.setenv("ORCHESTRA_STATE_FILE", "gs://test-bucket/k.json")
+
+        with gcs_patch(
+            mounts=[Mount("test-bucket", bucket_dir, readable=True, writable=True)]
+        ):
+            loaded = load_state()
+
+        assert "model.x" in loaded.state
+        assert loaded.state["model.x"].checksum == "c"
+
+    def test_load_state_gcs_credential_error_raises_state_load_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+        monkeypatch.setenv("ORCHESTRA_STATE_FILE", "gs://bucket/state.json")
+
+        from google.auth.exceptions import DefaultCredentialsError
+
+        with patch(
+            "orchestra_dbt.state_backends.gcs.storage.Client",
+            side_effect=DefaultCredentialsError("no credentials"),
+        ):
+            with pytest.raises(StateLoadError):
+                load_state()
+
+
+class TestSaveStateGCS:
+    def test_save_state_gcs_uploads_blob(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        bucket_dir = tmp_path / "gcs"
+        bucket_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+        monkeypatch.setenv("ORCHESTRA_STATE_FILE", "gs://bucket/dir/f.json")
+
+        with gcs_patch(
+            mounts=[Mount("bucket", bucket_dir, readable=True, writable=True)]
+        ):
+            save_state(
+                StateApiModel(
+                    state={
+                        "m": StateItem(
+                            last_updated=datetime(2024, 1, 1, 12, 0, 0),
+                            checksum="1",
+                            sources={},
+                        )
+                    }
+                )
+            )
+
+        body = (bucket_dir / "dir" / "f.json").read_text()
+        assert '"checksum"' in body
+
+    def test_save_state_gcs_credential_error_raises_state_save_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+        monkeypatch.setenv("ORCHESTRA_STATE_FILE", "gs://bucket/state.json")
+
+        from google.auth.exceptions import DefaultCredentialsError
+
+        with patch(
+            "orchestra_dbt.state_backends.gcs.storage.Client",
+            side_effect=DefaultCredentialsError("no credentials"),
+        ):
+            with pytest.raises(StateSaveError):
+                save_state(StateApiModel(state={}))

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -877,10 +877,15 @@ class TestLoadStateGCS:
         monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
         monkeypatch.setenv("ORCHESTRA_STATE_FILE", "gs://test-bucket/prefix/state.json")
 
+        # cloud-storage-mocker doesn't implement get_bucket; patch it to confirm
+        # the bucket exists so the missing-blob path is exercised.
+        from cloud_storage_mocker._core import Client as MockClient
+
         with gcs_patch(
             mounts=[Mount("test-bucket", tmp_path / "gcs", readable=True, writable=True)]
         ):
-            assert load_state() == StateApiModel(state={})
+            with patch.object(MockClient, "get_bucket", return_value=None, create=True):
+                assert load_state() == StateApiModel(state={})
 
     def test_load_state_gcs_success(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path

--- a/tests/unit/test_state_storage.py
+++ b/tests/unit/test_state_storage.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.orchestra_dbt.state_types import parse_s3_uri
+from src.orchestra_dbt.state_types import parse_gcs_uri, parse_s3_uri
 
 
 @pytest.mark.parametrize(
@@ -27,3 +27,47 @@ def test_parse_s3_uri_ok(uri: str, bucket: str, key: str) -> None:
 def test_parse_s3_uri_invalid(uri: str) -> None:
     with pytest.raises(ValueError):
         parse_s3_uri(uri)
+
+
+@pytest.mark.parametrize(
+    "uri, bucket, key",
+    [
+        ("gs://my-bucket/path/to/state.json", "my-bucket", "path/to/state.json"),
+        ("GS://B/path/k.json", "B", "path/k.json"),
+        ("gs://bucket/single", "bucket", "single"),
+    ],
+)
+def test_parse_gcs_uri_ok(uri: str, bucket: str, key: str) -> None:
+    assert parse_gcs_uri(uri) == (bucket, key)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://bucket/key",
+        "gs://bucket-only",
+        "gs://",
+        "",
+    ],
+)
+def test_parse_gcs_uri_invalid(uri: str) -> None:
+    with pytest.raises(ValueError):
+        parse_gcs_uri(uri)
+
+
+from src.orchestra_dbt.state_backends.factory import resolve_state_backend_config
+from src.orchestra_dbt.state_types import StateBackendKind
+
+
+def test_gs_uri_routes_to_gcs_backend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+    monkeypatch.setenv("ORCHESTRA_STATE_FILE", "gs://my-bucket/path/state.json")
+
+    cfg = resolve_state_backend_config()
+
+    assert cfg.kind == StateBackendKind.GCS
+    assert cfg.gcs_bucket == "my-bucket"
+    assert cfg.gcs_key == "path/state.json"

--- a/tests/unit/test_state_storage.py
+++ b/tests/unit/test_state_storage.py
@@ -1,6 +1,11 @@
 import pytest
 
-from src.orchestra_dbt.state_types import parse_gcs_uri, parse_s3_uri
+from src.orchestra_dbt.state_backends.factory import resolve_state_backend_config
+from src.orchestra_dbt.state_types import (
+    StateBackendKind,
+    parse_gcs_uri,
+    parse_s3_uri,
+)
 
 
 @pytest.mark.parametrize(
@@ -53,10 +58,6 @@ def test_parse_gcs_uri_ok(uri: str, bucket: str, key: str) -> None:
 def test_parse_gcs_uri_invalid(uri: str) -> None:
     with pytest.raises(ValueError):
         parse_gcs_uri(uri)
-
-
-from src.orchestra_dbt.state_backends.factory import resolve_state_backend_config
-from src.orchestra_dbt.state_types import StateBackendKind
 
 
 def test_gs_uri_routes_to_gcs_backend(

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11, <3.14"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "agate"
@@ -256,6 +260,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cloud-storage-mocker"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-cloud-storage" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/19/acbd4e8b5265464c9f277e679ebfcae6e5c50acb8e8f337db733832a1036/cloud_storage_mocker-0.3.4.tar.gz", hash = "sha256:a16bac982fbf2810340295c6d556e5e95b79a90671151d8657b868c0583ac64f", size = 6880, upload-time = "2024-02-21T09:13:06.581Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/80/92588d35fd5897230823f8d323e0a9b379104781fc0451d2a81bee144678/cloud_storage_mocker-0.3.4-py3-none-any.whl", hash = "sha256:87be5ad2fa6f34f27e4aec9654ccd4f82e26f988a4267d076ff72f21ec1e1715", size = 7054, upload-time = "2024-02-21T09:13:02.243Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -441,11 +457,15 @@ debug = [
 dev = [
     { name = "basedpyright" },
     { name = "boto3" },
+    { name = "cloud-storage-mocker" },
     { name = "dbt-core" },
     { name = "moto", extra = ["s3"] },
     { name = "pytest" },
     { name = "pytest-httpx" },
     { name = "ruff" },
+]
+gcs = [
+    { name = "google-cloud-storage" },
 ]
 s3 = [
     { name = "boto3" },
@@ -459,8 +479,10 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 's3'" },
     { name = "click" },
+    { name = "cloud-storage-mocker", marker = "extra == 'dev'" },
     { name = "dbt-core", marker = "extra == 'dev'", specifier = ">=1.10,<1.12" },
     { name = "dbt-postgres", marker = "extra == 'adapters'" },
+    { name = "google-cloud-storage", marker = "extra == 'gcs'" },
     { name = "graphviz", marker = "extra == 'debug'" },
     { name = "httpx" },
     { name = "moto", extras = ["s3"], marker = "extra == 'dev'" },
@@ -472,7 +494,7 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev", "adapters", "debug", "s3"]
+provides-extras = ["dev", "adapters", "debug", "s3", "gcs"]
 
 [[package]]
 name = "dbt-postgres"
@@ -532,6 +554,114 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/50/767448e792d41bfb6094ee317a355c1cb221dca24b2e178e2203bbea2a77/deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e", size = 634860, upload-time = "2026-03-18T17:16:33.785Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/5f/c52bd1255db763d0cdcb7084d2e90c42119cb229302c56bdf1d0aa78abd2/deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4", size = 91979, upload-time = "2026-03-18T17:16:32.171Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb", size = 349379, upload-time = "2026-06-15T22:33:16.466Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a", size = 252400, upload-time = "2026-06-15T22:33:14.992Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl", hash = "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c", size = 340605, upload-time = "2026-06-12T18:03:12.677Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -886,6 +1016,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -948,6 +1090,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `GCSStateBackend` supporting `gs://bucket/key` URIs, mirroring the existing S3 backend
- Authentication via Application Default Credentials only (consistent with S3's AWS credential chain approach)
- New `gcs = ["google-cloud-storage"]` optional dependency — only loaded when a `gs://` URI is configured

## Test Plan
- [x] 165 unit tests pass (`uv run --extra dev --extra gcs python -m pytest tests/unit/`)
- [x] Missing blob returns empty state (first-run behaviour)
- [x] Successful load and save via `cloud-storage-mocker`
- [x] `DefaultCredentialsError` surfaces as `StateLoadError`/`StateSaveError` with ADC setup hint
- [x] `gs://` URI routes correctly through factory to `GCSStateBackend`
