### PR TITLE
feat: add Azure Blob Storage state backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,36 @@ If you want to run state-aware dbt Core code without managing state files and th
 
 To store your dbt Core state in S3, install the optional dependency (`pip install 'dbt-orchestra[s3]'` or `uv sync --extra s3`). Credentials and region follow the usual [AWS SDK resolution](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) (environment variables, shared config, IAM role, etc.). If the object does not exist yet, load starts with an empty state and save creates the object. The state file parameter expects a `s3://bucket/key` URI.
 
+### GCS backend
+
+To store your dbt Core state in Google Cloud Storage, install the optional dependency (`pip install 'dbt-orchestra[gcs]'` or `uv sync --extra gcs`). Credentials follow [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials) — run `gcloud auth application-default login` for local development, or set `GOOGLE_APPLICATION_CREDENTIALS` to a service account key file, or rely on the attached service account when running on GCP. The bucket must already exist; if the object does not exist yet, load starts with an empty state and save creates the object. The state file parameter expects a `gs://bucket/key` URI.
+
+```toml
+[tool.orchestra_dbt]
+use_stateful = true
+state_file = "gs://my-bucket/dbt_state.json"
+```
+
+```bash
+gcloud auth application-default login   # once, for local dev
+orc dbt run
+```
+
+### ABS backend
+
+To store your dbt Core state in Azure Blob Storage, install the optional dependency (`pip install 'dbt-orchestra[azure]'` or `uv sync --extra azure`). Credentials follow [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication/credential-chains#defaultazurecredential-overview) — run `az login` for local development, or configure a service principal via `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_TENANT_ID`, or rely on the attached managed identity when running on Azure. Alternatively, set `AZURE_STORAGE_CONNECTION_STRING` for simpler setups. The container must already exist; if the blob does not exist yet, load starts with an empty state and save creates the blob. The state file parameter expects an `abfs://` or `abfss://` URI of the form `abfss://container@account.dfs.core.windows.net/path`. Both schemes always connect via TLS.
+
+```toml
+[tool.orchestra_dbt]
+use_stateful = true
+state_file = "abfss://my-container@my-account.dfs.core.windows.net/dbt_state.json"
+```
+
+```bash
+az login   # once, for local dev
+orc dbt run
+```
+
 ## Daily usage
 
 Stateful orchestration only runs for `dbt build`, `dbt run`, and `dbt test`. Other dbt subcommands are passed through to dbt unchanged.
@@ -130,7 +160,7 @@ For boolean settings, if the environment variable is **set**, the merged value i
 
 | Key | Type | Default | Purpose |
 | --- | --- | --- | --- |
-| `state_file` | string (optional) | — | Local JSON path or `s3://bucket/key` for state (see backend table below). |
+| `state_file` | string (optional) | — | Local JSON path, `s3://bucket/key`, `gs://bucket/key`, or `abfss://container@account.dfs.core.windows.net/key` for state (see [backend table](#state-backends) above). |
 | `use_stateful` | bool | `false` | Turn on stateful orchestration for supported dbt commands. |
 | `local_run` | bool | `true` | After reuse, revert patched files (typical for local iteration). |
 | `debug` | bool | `false` | Verbose logging. |
@@ -141,10 +171,10 @@ For boolean settings, if the environment variable is **set**, the merged value i
 | Priority | Setting | Effect |
 | --- | --- | --- |
 | 1 | `ORCHESTRA_API_KEY` | Load/save state via Orchestra HTTP. When the API key is set, `ORCHESTRA_STATE_FILE` and `state_file` in `pyproject.toml` are **ignored** for choosing the state backend. |
-| 2 | `ORCHESTRA_STATE_FILE` | Path to a JSON file, or `s3://bucket/key` for an object in S3. Relative file paths are resolved from the current working directory. Used only when `ORCHESTRA_API_KEY` is unset. |
-| 3 | `[tool.orchestra_dbt]` / `state_file` in `pyproject.toml` | Path to a JSON file, or `s3://bucket/key`. Relative file paths are resolved from the directory that contains the **discovered** `pyproject.toml`; absolute paths are used as-is. Used only when `ORCHESTRA_API_KEY` is unset and `ORCHESTRA_STATE_FILE` is unset. |
+| 2 | `ORCHESTRA_STATE_FILE` | Path to a JSON file, or `s3://bucket/key`, `gs://bucket/key`, or `abfss://container@account.dfs.core.windows.net/key`. Relative file paths are resolved from the current working directory. Used only when `ORCHESTRA_API_KEY` is unset. |
+| 3 | `[tool.orchestra_dbt]` / `state_file` in `pyproject.toml` | Path to a JSON file, or `s3://bucket/key`, `gs://bucket/key`, or `abfss://container@account.dfs.core.windows.net/key`. Relative file paths are resolved from the directory that contains the **discovered** `pyproject.toml`; absolute paths are used as-is. Used only when `ORCHESTRA_API_KEY` is unset and `ORCHESTRA_STATE_FILE` is unset. |
 
-If an effective local path or S3 URI is configured (rows 2 or 3), that **file** or **S3** backend is used and an API key is not required for state. If `ORCHESTRA_API_KEY` is set (row 1), the **HTTP backend** is used regardless of file settings.
+If an effective local path, S3, GCS, or ABS URI is configured (rows 2 or 3), that backend is used and an API key is not required for state. If `ORCHESTRA_API_KEY` is set (row 1), the **HTTP backend** is used regardless of file settings.
 
 ### Warehouse adapters and implicit source freshness
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ s3 = ["boto3"]
 # GCS-backed state (optional; google-cloud-storage loaded only when GCS URI is configured)
 gcs = ["google-cloud-storage"]
 
+# Azure Blob Storage-backed state (optional; azure-storage-blob and azure-identity loaded only when ABFSS URI is configured)
+azure = ["azure-storage-blob", "azure-identity"]
+
 [project.scripts]
 orc = "orchestra_dbt.cli:main"
 
@@ -69,3 +72,9 @@ where = ["src"]
 
 [tool.uv]
 package = true
+
+[dependency-groups]
+dev = [
+    "azure-identity>=1.25.3",
+    "azure-storage-blob>=12.30.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ Security = "https://github.com/orchestra-hq/sao-paolo/security/policy"
 
 [project.optional-dependencies]
 dev = [
+    "azure-identity>=1.25.3",
+    "azure-storage-blob>=12.30.0",
     "basedpyright",
     "boto3",
     "cloud-storage-mocker",
@@ -72,9 +74,3 @@ where = ["src"]
 
 [tool.uv]
 package = true
-
-[dependency-groups]
-dev = [
-    "azure-identity>=1.25.3",
-    "azure-storage-blob>=12.30.0",
-]

--- a/src/orchestra_dbt/state_backends/azure.py
+++ b/src/orchestra_dbt/state_backends/azure.py
@@ -13,6 +13,16 @@ from ..state_filters import apply_integration_account_filter
 from .logging import log_state_loaded, log_state_saved
 
 
+def _account_from_connection_string(conn_str: str) -> str | None:
+    # Connection strings are `key=value;key=value;...`. AccountKey values are
+    # base64 and may themselves contain `=`, so split on the first `=` only.
+    for part in conn_str.split(";"):
+        name, sep, value = part.partition("=")
+        if sep and name.strip().lower() == "accountname":
+            return value.strip()
+    return None
+
+
 class AzureStateBackend:
     def __init__(self, account: str, container: str, key: str) -> None:
         self._account = account
@@ -20,11 +30,22 @@ class AzureStateBackend:
         self._key = key
 
     def _get_client(self) -> BlobServiceClient:
-        # The clients construct lazily and do not authenticate until a blob
-        # operation runs, so credential failures surface in load()/save() rather
-        # than here.
+        # Credential auth is lazy (no token is acquired until the first blob
+        # call), so auth failures surface in load()/save(). Connection-string
+        # parsing, however, happens eagerly here and can raise ValueError; callers
+        # wrap this method so such setup errors become StateLoad/SaveError.
         conn_str = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
         if conn_str:
+            # The URI is authoritative for which account/container/blob we touch
+            # (mirroring S3/GCS). A connection string for a different account would
+            # silently read/write the wrong place, so reject the mismatch.
+            conn_account = _account_from_connection_string(conn_str)
+            if conn_account and conn_account.lower() != self._account.lower():
+                raise ValueError(
+                    f"AZURE_STORAGE_CONNECTION_STRING is for account "
+                    f"'{conn_account}', but the configured state URI targets "
+                    f"account '{self._account}'. These must match."
+                )
             return BlobServiceClient.from_connection_string(conn_str)
         return BlobServiceClient(
             f"https://{self._account}.blob.core.windows.net",
@@ -35,7 +56,12 @@ class AzureStateBackend:
         account, container, key = self._account, self._container, self._key
         uri = f"abfss://{container}@{account}.dfs.core.windows.net/{key}"
 
-        client = self._get_client()
+        try:
+            client = self._get_client()
+        except Exception as e:
+            raise StateLoadError(
+                f"Failed to initialize Azure client for {uri}: {e}"
+            ) from e
 
         try:
             blob_client = client.get_blob_client(container=container, blob=key)
@@ -88,7 +114,12 @@ class AzureStateBackend:
         account, container, key = self._account, self._container, self._key
         uri = f"abfss://{container}@{account}.dfs.core.windows.net/{key}"
 
-        client = self._get_client()
+        try:
+            client = self._get_client()
+        except Exception as e:
+            raise StateSaveError(
+                f"Failed to initialize Azure client for {uri}: {e}"
+            ) from e
 
         payload = state.model_dump_json(exclude_none=True).encode("utf-8")
         try:

--- a/src/orchestra_dbt/state_backends/azure.py
+++ b/src/orchestra_dbt/state_backends/azure.py
@@ -20,6 +20,9 @@ class AzureStateBackend:
         self._key = key
 
     def _get_client(self) -> BlobServiceClient:
+        # The clients construct lazily and do not authenticate until a blob
+        # operation runs, so credential failures surface in load()/save() rather
+        # than here.
         conn_str = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
         if conn_str:
             return BlobServiceClient.from_connection_string(conn_str)
@@ -32,13 +35,7 @@ class AzureStateBackend:
         account, container, key = self._account, self._container, self._key
         uri = f"abfss://{container}@{account}.dfs.core.windows.net/{key}"
 
-        try:
-            client = self._get_client()
-        except ClientAuthenticationError as e:
-            raise StateLoadError(
-                f"Azure credentials not found. Run `az login` or set "
-                f"AZURE_STORAGE_CONNECTION_STRING. Details: {e}"
-            ) from e
+        client = self._get_client()
 
         try:
             blob_client = client.get_blob_client(container=container, blob=key)
@@ -47,10 +44,6 @@ class AzureStateBackend:
         except ResourceNotFoundError:
             try:
                 container_exists = client.get_container_client(container).exists()
-            except (HttpResponseError, ClientAuthenticationError) as e:
-                raise StateLoadError(
-                    f"Failed to check container '{container}' in account '{account}': {e}"
-                ) from e
             except Exception as e:
                 raise StateLoadError(
                     f"Failed to check container '{container}' in account '{account}': {e}"
@@ -61,7 +54,13 @@ class AzureStateBackend:
                 )
             log_info(f"No state blob at {uri}; starting with empty state.")
             return StateApiModel(state={})
-        except (HttpResponseError, ClientAuthenticationError) as e:
+        except ClientAuthenticationError as e:
+            # Must precede HttpResponseError: ClientAuthenticationError is a subclass.
+            raise StateLoadError(
+                f"Azure credentials not found or invalid while reading {uri}. "
+                f"Run `az login` or set AZURE_STORAGE_CONNECTION_STRING. Details: {e}"
+            ) from e
+        except HttpResponseError as e:
             raise StateLoadError(
                 f"Permission denied reading {uri}. "
                 f"Ensure the identity has the 'Storage Blob Data Reader' role: {e}"
@@ -89,13 +88,7 @@ class AzureStateBackend:
         account, container, key = self._account, self._container, self._key
         uri = f"abfss://{container}@{account}.dfs.core.windows.net/{key}"
 
-        try:
-            client = self._get_client()
-        except ClientAuthenticationError as e:
-            raise StateSaveError(
-                f"Azure credentials not found. Run `az login` or set "
-                f"AZURE_STORAGE_CONNECTION_STRING. Details: {e}"
-            ) from e
+        client = self._get_client()
 
         payload = state.model_dump_json(exclude_none=True).encode("utf-8")
         try:
@@ -107,7 +100,13 @@ class AzureStateBackend:
                     content_type="application/json; charset=utf-8"
                 ),
             )
-        except (HttpResponseError, ClientAuthenticationError) as e:
+        except ClientAuthenticationError as e:
+            # Must precede HttpResponseError: ClientAuthenticationError is a subclass.
+            raise StateSaveError(
+                f"Azure credentials not found or invalid while writing {uri}. "
+                f"Run `az login` or set AZURE_STORAGE_CONNECTION_STRING. Details: {e}"
+            ) from e
+        except HttpResponseError as e:
             raise StateSaveError(
                 f"Permission denied writing {uri}. "
                 f"Ensure the identity has the 'Storage Blob Data Contributor' role: {e}"

--- a/src/orchestra_dbt/state_backends/azure.py
+++ b/src/orchestra_dbt/state_backends/azure.py
@@ -1,0 +1,118 @@
+import json
+import os
+
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, ResourceNotFoundError
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient, ContentSettings
+from pydantic import ValidationError
+
+from ..logger import log_info
+from ..models import StateApiModel
+from ..state_errors import StateLoadError, StateSaveError
+from ..state_filters import apply_integration_account_filter
+from .logging import log_state_loaded, log_state_saved
+
+
+class AzureStateBackend:
+    def __init__(self, account: str, container: str, key: str) -> None:
+        self._account = account
+        self._container = container
+        self._key = key
+
+    def _get_client(self) -> BlobServiceClient:
+        conn_str = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+        if conn_str:
+            return BlobServiceClient.from_connection_string(conn_str)
+        return BlobServiceClient(
+            f"https://{self._account}.blob.core.windows.net",
+            credential=DefaultAzureCredential(),
+        )
+
+    def load(self) -> StateApiModel:
+        account, container, key = self._account, self._container, self._key
+        uri = f"abfss://{container}@{account}.dfs.core.windows.net/{key}"
+
+        try:
+            client = self._get_client()
+        except ClientAuthenticationError as e:
+            raise StateLoadError(
+                f"Azure credentials not found. Run `az login` or set "
+                f"AZURE_STORAGE_CONNECTION_STRING. Details: {e}"
+            ) from e
+
+        try:
+            blob_client = client.get_blob_client(container=container, blob=key)
+            download = blob_client.download_blob()
+            raw = download.readall().decode("utf-8")
+        except ResourceNotFoundError:
+            try:
+                container_exists = client.get_container_client(container).exists()
+            except (HttpResponseError, ClientAuthenticationError) as e:
+                raise StateLoadError(
+                    f"Failed to check container '{container}' in account '{account}': {e}"
+                ) from e
+            except Exception as e:
+                raise StateLoadError(
+                    f"Failed to check container '{container}' in account '{account}': {e}"
+                ) from e
+            if not container_exists:
+                raise StateLoadError(
+                    f"Azure container '{container}' in account '{account}' does not exist."
+                )
+            log_info(f"No state blob at {uri}; starting with empty state.")
+            return StateApiModel(state={})
+        except (HttpResponseError, ClientAuthenticationError) as e:
+            raise StateLoadError(
+                f"Permission denied reading {uri}. "
+                f"Ensure the identity has the 'Storage Blob Data Reader' role: {e}"
+            ) from e
+        except Exception as e:
+            raise StateLoadError(f"Failed to load state from {uri}: {e}") from e
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise StateLoadError(f"State blob at {uri} is not valid JSON: {e}") from e
+
+        try:
+            state = StateApiModel.model_validate(data)
+        except (ValidationError, ValueError) as e:
+            raise StateLoadError(
+                f"State blob at {uri} failed validation: {e}"
+            ) from e
+
+        apply_integration_account_filter(state)
+        log_state_loaded("azure", state)
+        return state
+
+    def save(self, state: StateApiModel) -> None:
+        account, container, key = self._account, self._container, self._key
+        uri = f"abfss://{container}@{account}.dfs.core.windows.net/{key}"
+
+        try:
+            client = self._get_client()
+        except ClientAuthenticationError as e:
+            raise StateSaveError(
+                f"Azure credentials not found. Run `az login` or set "
+                f"AZURE_STORAGE_CONNECTION_STRING. Details: {e}"
+            ) from e
+
+        payload = state.model_dump_json(exclude_none=True).encode("utf-8")
+        try:
+            blob_client = client.get_blob_client(container=container, blob=key)
+            blob_client.upload_blob(
+                payload,
+                overwrite=True,
+                content_settings=ContentSettings(
+                    content_type="application/json; charset=utf-8"
+                ),
+            )
+        except (HttpResponseError, ClientAuthenticationError) as e:
+            raise StateSaveError(
+                f"Permission denied writing {uri}. "
+                f"Ensure the identity has the 'Storage Blob Data Contributor' role: {e}"
+            ) from e
+        except Exception as e:
+            raise StateSaveError(f"Failed to save state to {uri}: {e}") from e
+
+        log_state_saved("azure")

--- a/src/orchestra_dbt/state_backends/factory.py
+++ b/src/orchestra_dbt/state_backends/factory.py
@@ -68,3 +68,11 @@ def resolved_state_backend(cwd: Path | None = None) -> StateBackend:
                     "State backend config is GCS but gcs_bucket or gcs_key is missing"
                 )
             return GCSStateBackend(cfg.gcs_bucket, cfg.gcs_key)
+        case StateBackendKind.AZURE:
+            from .azure import AzureStateBackend
+
+            if cfg.azure_account is None or cfg.azure_container is None or cfg.azure_key is None:
+                raise RuntimeError(
+                    "State backend config is AZURE but azure_account, azure_container, or azure_key is missing"
+                )
+            return AzureStateBackend(cfg.azure_account, cfg.azure_container, cfg.azure_key)

--- a/src/orchestra_dbt/state_backends/logging.py
+++ b/src/orchestra_dbt/state_backends/logging.py
@@ -3,13 +3,14 @@ from typing import Literal
 from ..logger import log_info
 from ..models import StateApiModel
 
-StateBackendLabel = Literal["http", "local_file", "s3", "gcs"]
+StateBackendLabel = Literal["http", "local_file", "s3", "gcs", "azure"]
 
 _LOAD_MESSAGE_LABEL: dict[StateBackendLabel, str] = {
     "http": "Orchestra HTTP",
     "local_file": "local file",
     "s3": "S3",
     "gcs": "GCS",
+    "azure": "Azure Blob Storage",
 }
 
 
@@ -19,7 +20,7 @@ def log_state_loaded(backend: StateBackendLabel, state: StateApiModel) -> None:
 
 
 def log_state_saved(backend: StateBackendLabel) -> None:
-    if backend in ("s3", "gcs"):
+    if backend in ("s3", "gcs", "azure"):
         log_info(f"State saved to {_LOAD_MESSAGE_LABEL[backend]}")
     else:
         log_info("State saved")

--- a/src/orchestra_dbt/state_types.py
+++ b/src/orchestra_dbt/state_types.py
@@ -9,6 +9,7 @@ class StateBackendKind(str, Enum):
     LOCAL_FILE = "local_file"
     S3 = "s3"
     GCS = "gcs"
+    AZURE = "azure"
 
 
 class StateBackendConfig(BaseModel):
@@ -20,6 +21,9 @@ class StateBackendConfig(BaseModel):
     s3_key: str | None = None
     gcs_bucket: str | None = None
     gcs_key: str | None = None
+    azure_account: str | None = None
+    azure_container: str | None = None
+    azure_key: str | None = None
 
 
 def parse_s3_uri(uri: str) -> tuple[str, str]:
@@ -58,6 +62,35 @@ def parse_gcs_uri(uri: str) -> tuple[str, str]:
     return bucket, key
 
 
+def parse_abfs_uri(uri: str) -> tuple[str, str, str]:
+    lower = uri.lower()
+    if lower.startswith("abfss://"):
+        prefix = "abfss://"
+    elif lower.startswith("abfs://"):
+        prefix = "abfs://"
+    else:
+        msg = f"Expected ABFS URI starting with 'abfs://' or 'abfss://', got: {uri!r}"
+        raise ValueError(msg)
+    rest = uri[len(prefix) :]
+    # authority is container@account.dfs.core.windows.net
+    if "/" not in rest:
+        msg = f"ABFS URI must include a path after the authority: {uri!r}"
+        raise ValueError(msg)
+    authority, _, key = rest.partition("/")
+    key = key.lstrip("/")
+    if "@" not in authority:
+        msg = f"ABFS URI authority must be container@account.dfs.core.windows.net: {uri!r}"
+        raise ValueError(msg)
+    container, _, host = authority.partition("@")
+    account = host.split(".")[0]
+    container = container.strip()
+    account = account.strip()
+    if not container or not account or not key:
+        msg = f"Invalid ABFS URI (container, account, and path required): {uri!r}"
+        raise ValueError(msg)
+    return account, container, key
+
+
 def backend_config_from_state_location(
     raw: str, resolve_relative_from: Path
 ) -> StateBackendConfig:
@@ -75,6 +108,14 @@ def backend_config_from_state_location(
             kind=StateBackendKind.GCS,
             gcs_bucket=bucket,
             gcs_key=key,
+        )
+    if stripped.lower().startswith(("abfs://", "abfss://")):
+        account, container, key = parse_abfs_uri(stripped)
+        return StateBackendConfig(
+            kind=StateBackendKind.AZURE,
+            azure_account=account,
+            azure_container=container,
+            azure_key=key,
         )
     p = Path(stripped).expanduser()
     if p.is_absolute():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 @pytest.fixture(autouse=True)
 def mock_env_vars(monkeypatch):
     monkeypatch.delenv("ORCHESTRA_STATE_FILE", raising=False)
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
     monkeypatch.setenv("ORCHESTRA_API_KEY", "test-api-key")
     monkeypatch.setenv("ORCHESTRA_ENV", "dev")
     yield

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1076,7 +1076,7 @@ class TestAzureStateBackend:
         with pytest.raises(StateSaveError):
             backend.save(StateApiModel(state={}))
 
-    @patch.dict("os.environ", {"AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=fake;EndpointSuffix=core.windows.net"})
+    @patch.dict("os.environ", {"AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=fake;EndpointSuffix=core.windows.net"})
     @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
     def test_load_uses_connection_string_when_set(self, mock_client_cls):
         payload = '{"state": {}}'
@@ -1118,3 +1118,52 @@ class TestAzureStateBackend:
         mock_credential_cls.assert_called_once()
         mock_client_cls.assert_called_once()
         assert result == StateApiModel(state={})
+
+    @patch.dict("os.environ", {"AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=otheraccount;AccountKey=fake;EndpointSuffix=core.windows.net"})
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    def test_load_raises_when_connection_string_account_mismatches_uri(
+        self, mock_client_cls
+    ):
+        from src.orchestra_dbt.state_errors import StateLoadError
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        with pytest.raises(StateLoadError, match="must match"):
+            backend.load()
+
+        mock_client_cls.from_connection_string.assert_not_called()
+
+    @patch.dict("os.environ", {"AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=otheraccount;AccountKey=fake;EndpointSuffix=core.windows.net"})
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    def test_save_raises_when_connection_string_account_mismatches_uri(
+        self, mock_client_cls
+    ):
+        from src.orchestra_dbt.state_errors import StateSaveError
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        with pytest.raises(StateSaveError, match="must match"):
+            backend.save(StateApiModel(state={}))
+
+        mock_client_cls.from_connection_string.assert_not_called()
+
+    @patch.dict("os.environ", {"AZURE_STORAGE_CONNECTION_STRING": "not-a-valid-connection-string"})
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    def test_load_wraps_invalid_connection_string_as_state_load_error(
+        self, mock_client_cls
+    ):
+        from src.orchestra_dbt.state_errors import StateLoadError
+
+        mock_client_cls.from_connection_string.side_effect = ValueError(
+            "Connection string missing required connection details."
+        )
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        # Account name is absent from the string, so the mismatch guard passes and
+        # from_connection_string runs and raises — which must surface as StateLoadError.
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        with pytest.raises(StateLoadError, match="initialize Azure client"):
+            backend.load()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import boto3
 import httpx
@@ -969,3 +969,152 @@ class TestSaveStateGCS:
         ):
             with pytest.raises(StateSaveError):
                 save_state(StateApiModel(state={}))
+
+
+class TestAzureStateBackend:
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    @patch("src.orchestra_dbt.state_backends.azure.DefaultAzureCredential")
+    def test_load_returns_empty_state_when_blob_missing(
+        self, mock_credential, mock_client_cls
+    ):
+        from azure.core.exceptions import ResourceNotFoundError
+
+        mock_blob_client = MagicMock()
+        mock_blob_client.download_blob.side_effect = ResourceNotFoundError("not found")
+        mock_container_client = MagicMock()
+        mock_container_client.exists.return_value = True
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob_client
+        mock_service.get_container_client.return_value = mock_container_client
+        mock_client_cls.return_value = mock_service
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        result = backend.load()
+
+        assert result == StateApiModel(state={})
+
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    @patch("src.orchestra_dbt.state_backends.azure.DefaultAzureCredential")
+    def test_load_raises_when_container_missing(
+        self, mock_credential, mock_client_cls
+    ):
+        from azure.core.exceptions import ResourceNotFoundError
+        from src.orchestra_dbt.state_errors import StateLoadError
+
+        mock_blob_client = MagicMock()
+        mock_blob_client.download_blob.side_effect = ResourceNotFoundError("not found")
+        mock_container_client = MagicMock()
+        mock_container_client.exists.return_value = False
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob_client
+        mock_service.get_container_client.return_value = mock_container_client
+        mock_client_cls.return_value = mock_service
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        with pytest.raises(StateLoadError, match="container"):
+            backend.load()
+
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    @patch("src.orchestra_dbt.state_backends.azure.DefaultAzureCredential")
+    def test_load_returns_valid_state(self, mock_credential, mock_client_cls):
+        payload = '{"state": {"model.test": {"checksum": "abc", "last_updated": "2024-01-01T12:00:00", "sources": {}}}}'
+        mock_download = MagicMock()
+        mock_download.readall.return_value = payload.encode("utf-8")
+        mock_blob_client = MagicMock()
+        mock_blob_client.download_blob.return_value = mock_download
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob_client
+        mock_client_cls.return_value = mock_service
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        result = backend.load()
+
+        assert "model.test" in result.state
+        assert result.state["model.test"].checksum == "abc"
+
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    @patch("src.orchestra_dbt.state_backends.azure.DefaultAzureCredential")
+    def test_save_uploads_json(self, mock_credential, mock_client_cls):
+        mock_blob_client = MagicMock()
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob_client
+        mock_client_cls.return_value = mock_service
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        backend.save(StateApiModel(state={}))
+
+        mock_blob_client.upload_blob.assert_called_once()
+        call_kwargs = mock_blob_client.upload_blob.call_args
+        assert call_kwargs.kwargs.get("overwrite") is True
+        assert call_kwargs.kwargs.get("content_settings") is not None
+
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    @patch("src.orchestra_dbt.state_backends.azure.DefaultAzureCredential")
+    def test_save_raises_on_auth_error(self, mock_credential, mock_client_cls):
+        from azure.core.exceptions import HttpResponseError
+        from src.orchestra_dbt.state_errors import StateSaveError
+
+        mock_blob_client = MagicMock()
+        mock_blob_client.upload_blob.side_effect = HttpResponseError(
+            message="AuthorizationFailure"
+        )
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob_client
+        mock_client_cls.return_value = mock_service
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        with pytest.raises(StateSaveError):
+            backend.save(StateApiModel(state={}))
+
+    @patch.dict("os.environ", {"AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=fake;EndpointSuffix=core.windows.net"})
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    def test_load_uses_connection_string_when_set(self, mock_client_cls):
+        payload = '{"state": {}}'
+        mock_download = MagicMock()
+        mock_download.readall.return_value = payload.encode("utf-8")
+        mock_blob_client = MagicMock()
+        mock_blob_client.download_blob.return_value = mock_download
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob_client
+        mock_client_cls.from_connection_string.return_value = mock_service
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        result = backend.load()
+
+        mock_client_cls.from_connection_string.assert_called_once()
+        assert result == StateApiModel(state={})
+
+    @patch("src.orchestra_dbt.state_backends.azure.BlobServiceClient")
+    @patch("src.orchestra_dbt.state_backends.azure.DefaultAzureCredential")
+    def test_load_uses_default_credential_when_no_connection_string(
+        self, mock_credential_cls, mock_client_cls
+    ):
+        payload = '{"state": {}}'
+        mock_download = MagicMock()
+        mock_download.readall.return_value = payload.encode("utf-8")
+        mock_blob_client = MagicMock()
+        mock_blob_client.download_blob.return_value = mock_download
+        mock_service = MagicMock()
+        mock_service.get_blob_client.return_value = mock_blob_client
+        mock_client_cls.return_value = mock_service
+
+        from src.orchestra_dbt.state_backends.azure import AzureStateBackend
+
+        backend = AzureStateBackend("myaccount", "mycontainer", "state.json")
+        result = backend.load()
+
+        mock_credential_cls.assert_called_once()
+        mock_client_cls.assert_called_once()
+        assert result == StateApiModel(state={})

--- a/tests/unit/test_state_storage.py
+++ b/tests/unit/test_state_storage.py
@@ -3,6 +3,7 @@ import pytest
 from src.orchestra_dbt.state_backends.factory import resolve_state_backend_config
 from src.orchestra_dbt.state_types import (
     StateBackendKind,
+    parse_abfs_uri,
     parse_gcs_uri,
     parse_s3_uri,
 )
@@ -72,3 +73,95 @@ def test_gs_uri_routes_to_gcs_backend(
     assert cfg.kind == StateBackendKind.GCS
     assert cfg.gcs_bucket == "my-bucket"
     assert cfg.gcs_key == "path/state.json"
+
+
+@pytest.mark.parametrize(
+    "uri, account, container, key",
+    [
+        (
+            "abfss://mycontainer@myaccount.dfs.core.windows.net/state.json",
+            "myaccount",
+            "mycontainer",
+            "state.json",
+        ),
+        (
+            "abfs://mycontainer@myaccount.dfs.core.windows.net/state.json",
+            "myaccount",
+            "mycontainer",
+            "state.json",
+        ),
+        (
+            "ABFSS://mycontainer@myaccount.dfs.core.windows.net/path/to/state.json",
+            "myaccount",
+            "mycontainer",
+            "path/to/state.json",
+        ),
+        (
+            "ABFS://mycontainer@myaccount.dfs.core.windows.net/path/to/state.json",
+            "myaccount",
+            "mycontainer",
+            "path/to/state.json",
+        ),
+        (
+            "abfss://mycontainer@myaccount.dfs.core.windows.net/nested/path/state.json",
+            "myaccount",
+            "mycontainer",
+            "nested/path/state.json",
+        ),
+    ],
+)
+def test_parse_abfs_uri_ok(uri: str, account: str, container: str, key: str) -> None:
+    assert parse_abfs_uri(uri) == (account, container, key)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://myaccount.blob.core.windows.net/container/key",
+        "abfss://container-only",
+        "abfs://container-only",
+        "abfss://",
+        "abfs://",
+        "abfss://container@account.dfs.core.windows.net",  # missing key
+        "",
+    ],
+)
+def test_parse_abfs_uri_invalid(uri: str) -> None:
+    with pytest.raises(ValueError):
+        parse_abfs_uri(uri)
+
+
+def test_abfss_uri_routes_to_azure_backend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+    monkeypatch.setenv(
+        "ORCHESTRA_STATE_FILE",
+        "abfss://mycontainer@myaccount.dfs.core.windows.net/path/state.json",
+    )
+
+    cfg = resolve_state_backend_config()
+
+    assert cfg.kind == StateBackendKind.AZURE
+    assert cfg.azure_account == "myaccount"
+    assert cfg.azure_container == "mycontainer"
+    assert cfg.azure_key == "path/state.json"
+
+
+def test_abfs_uri_routes_to_azure_backend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+    monkeypatch.setenv(
+        "ORCHESTRA_STATE_FILE",
+        "abfs://mycontainer@myaccount.dfs.core.windows.net/path/state.json",
+    )
+
+    cfg = resolve_state_backend_config()
+
+    assert cfg.kind == StateBackendKind.AZURE
+    assert cfg.azure_account == "myaccount"
+    assert cfg.azure_container == "mycontainer"
+    assert cfg.azure_key == "path/state.json"

--- a/uv.lock
+++ b/uv.lock
@@ -503,6 +503,8 @@ debug = [
     { name = "graphviz" },
 ]
 dev = [
+    { name = "azure-identity" },
+    { name = "azure-storage-blob" },
     { name = "basedpyright" },
     { name = "boto3" },
     { name = "cloud-storage-mocker" },
@@ -519,17 +521,13 @@ s3 = [
     { name = "boto3" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "azure-identity" },
-    { name = "azure-storage-blob" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "awscrt", marker = "extra == 'debug'" },
     { name = "azure-identity", marker = "extra == 'azure'" },
+    { name = "azure-identity", marker = "extra == 'dev'", specifier = ">=1.25.3" },
     { name = "azure-storage-blob", marker = "extra == 'azure'" },
+    { name = "azure-storage-blob", marker = "extra == 'dev'", specifier = ">=12.30.0" },
     { name = "basedpyright", marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 'debug'" },
     { name = "boto3", marker = "extra == 'dev'" },
@@ -551,12 +549,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev", "adapters", "debug", "s3", "gcs", "azure"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "azure-identity", specifier = ">=1.25.3" },
-    { name = "azure-storage-blob", specifier = ">=12.30.0" },
-]
 
 [[package]]
 name = "dbt-postgres"

--- a/uv.lock
+++ b/uv.lock
@@ -85,6 +85,50 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -449,6 +493,10 @@ dependencies = [
 adapters = [
     { name = "dbt-postgres" },
 ]
+azure = [
+    { name = "azure-identity" },
+    { name = "azure-storage-blob" },
+]
 debug = [
     { name = "awscrt" },
     { name = "boto3" },
@@ -471,9 +519,17 @@ s3 = [
     { name = "boto3" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "azure-identity" },
+    { name = "azure-storage-blob" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "awscrt", marker = "extra == 'debug'" },
+    { name = "azure-identity", marker = "extra == 'azure'" },
+    { name = "azure-storage-blob", marker = "extra == 'azure'" },
     { name = "basedpyright", marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 'debug'" },
     { name = "boto3", marker = "extra == 'dev'" },
@@ -494,7 +550,13 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev", "adapters", "debug", "s3", "gcs"]
+provides-extras = ["dev", "adapters", "debug", "s3", "gcs", "azure"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "azure-identity", specifier = ">=1.25.3" },
+    { name = "azure-storage-blob", specifier = ">=12.30.0" },
+]
 
 [[package]]
 name = "dbt-postgres"
@@ -911,6 +973,32 @@ s3 = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1216,6 +1304,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds Azure Blob Storage as a state backend, following up on #51 (GCS docs) as discussed with @ojc-orchestra.

- New `state_backends/azure.py` backend accepting either `abfs://` or `abfss://` URIs of the form `abfss://container@account.dfs.core.windows.net/key` (both connect via TLS)
- URI parsing in `state_types.py` and wiring into the backend factory + logging
- Optional `dbt-orchestra[azure]` install extra in `pyproject.toml`
- Auth via `DefaultAzureCredential` (`az login` locally, service principal env vars, or managed identity) or `AZURE_STORAGE_CONNECTION_STRING`; missing-blob loads start with empty state
- README section parallel to S3/GCS
- Unit tests for backend + URI parsing