### PR TITLE
Fix --full-refresh detection to match CLI/ env var behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `--full-refresh` detection (the switch that disables stateful orchestration for a run) now also recognizes the short flag `-f` and the `DBT_FULL_REFRESH` env var, not just a bare `--full-refresh` token. Previously `orc dbt build -f` or `DBT_FULL_REFRESH=true` triggered a real full refresh in the dbt subprocess while orchestra's own state-aware reuse logic ran as if it hadn't. Env var truthiness matches click's exact recognized states (`1/yes/true/on/t/y` vs `0/no/false/off/f/n/""`), and an explicit flag still wins over the environment.
+
 ## [1.1.1] - 2026-07-06
 
 ### Fixed

--- a/src/orchestra_dbt/cli.py
+++ b/src/orchestra_dbt/cli.py
@@ -15,6 +15,7 @@ from .config import (
 )
 from .constants import SERVICE_NAME
 from .dag import construct_dag
+from .full_refresh_finder import is_full_refresh_requested
 from .logger import log_debug, log_error, log_info, log_reused_nodes, log_warn
 from .ls import get_paths_to_run
 from .models import (
@@ -97,9 +98,7 @@ def _complete_run(
         state=state, parsed_dag=parsed_dag, source_freshness=source_freshness
     )
     try:
-        save_state(
-            state=state, updated_asset_external_ids=updated_asset_external_ids
-        )
+        save_state(state=state, updated_asset_external_ids=updated_asset_external_ids)
     except StateSaveError as e:
         # A save failure is only fatal if we had good state to begin with. If the
         # initial load already failed, we never had reliable state to protect, so
@@ -197,7 +196,7 @@ def main(args: tuple[str, ...]) -> None:
     # Propagate freshness config to upstream nodes
     propagate_freshness_config(parsed_dag)
 
-    if "--full-refresh" in dbt_args:
+    if is_full_refresh_requested(list(dbt_args)):
         log_info("Full refresh detected. Stateful orchestration disabled.")
         _complete_run(
             state,

--- a/src/orchestra_dbt/full_refresh_finder.py
+++ b/src/orchestra_dbt/full_refresh_finder.py
@@ -1,0 +1,17 @@
+import os
+
+# dbt/click's exact truthy env var states (case-insensitive, trimmed).
+_ENV_TRUE_STATES = {"1", "yes", "true", "on", "t", "y"}
+
+
+def is_full_refresh_requested(args: list[str]) -> bool:
+    """Resolve whether this dbt invocation runs with `--full-refresh`/`-f`/`DBT_FULL_REFRESH`.
+
+    Unlike `--target`, this is a plain boolean flag with no value (click rejects
+    `--full-refresh=true` outright), so presence of either flag always wins over the env var.
+    Bundled short flags (`-fs model`) aren't unpicked -- rare enough to skip.
+    """
+    if "--full-refresh" in args or "-f" in args:
+        return True
+
+    return os.environ.get("DBT_FULL_REFRESH", "").strip().lower() in _ENV_TRUE_STATES

--- a/tests/unit/test_full_refresh_finder.py
+++ b/tests/unit/test_full_refresh_finder.py
@@ -1,0 +1,51 @@
+import pytest
+
+from src.orchestra_dbt.full_refresh_finder import is_full_refresh_requested
+
+
+@pytest.fixture(autouse=True)
+def _no_dbt_full_refresh_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DBT_FULL_REFRESH", raising=False)
+
+
+class TestIsFullRefreshRequested:
+    """Unlike `--target`, this is a plain boolean flag with no value (click rejects
+    `--full-refresh=true` outright), so only flag presence and the env var matter here.
+    """
+
+    def test_absent_by_default(self) -> None:
+        assert is_full_refresh_requested(["dbt", "build"]) is False
+
+    def test_long_flag(self) -> None:
+        assert is_full_refresh_requested(["dbt", "build", "--full-refresh"]) is True
+
+    def test_short_flag(self) -> None:
+        assert is_full_refresh_requested(["dbt", "build", "-f"]) is True
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", " yes ", "1", "on", "t", "y"])
+    def test_env_var_true_states(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("DBT_FULL_REFRESH", value)
+        assert is_full_refresh_requested(["dbt", "build"]) is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "off", "f", "n", "no", ""])
+    def test_env_var_false_states(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("DBT_FULL_REFRESH", value)
+        assert is_full_refresh_requested(["dbt", "build"]) is False
+
+    def test_unrecognised_env_var_value_fails_toward_not_requested(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Real dbt/click would reject this outright; we fail toward not-requested instead."""
+        monkeypatch.setenv("DBT_FULL_REFRESH", "garbage")
+        assert is_full_refresh_requested(["dbt", "build"]) is False
+
+    def test_flag_beats_a_false_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DBT_FULL_REFRESH", "false")
+        assert is_full_refresh_requested(["dbt", "build", "--full-refresh"]) is True
+
+    def test_no_env_var_set_is_not_requested(self) -> None:
+        assert is_full_refresh_requested(["dbt", "build"]) is False


### PR DESCRIPTION
# Summary

Parses all options for the Full Refresh flag

## How to test

* Tests
* Run dbt with any of the combinations, i.e. `-f / --full-refresh` or env var `DBT_FULL_REFRESH=y / on / true / 1 / t / yes` and view logs

```bash
uv run pytest
uv run ruff check . && uv run ruff format --check . && uv run basedpyright
```

## Checklist

- [x] Tests added or updated where behaviour changed
- [x] Unit tests and linting pass locally
- [x] Documentation updated where necessary
- [x] Changelog updated for user-visible changes
