### PR TITLE
Fix dbt --target/-t argument parsing to parse all options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `--full-refresh` detection (the switch that disables stateful orchestration for a run) now also recognizes the short flag `-f` and the `DBT_FULL_REFRESH` env var, not just a bare `--full-refresh` token. Previously `orc dbt build -f` or `DBT_FULL_REFRESH=true` triggered a real full refresh in the dbt subprocess while orchestra's own state-aware reuse logic ran as if it hadn't. Env var truthiness matches click's exact recognized states (`1/yes/true/on/t/y` vs `0/no/false/off/f/n/""`), and an explicit flag still wins over the environment.
+- `--target` is now resolved from `--target=<name>`, `-t <name>`, `-tname` and `DBT_TARGET`, not just a bare `--target <name>`. Previously those forms silently fell back to the default target, so anything relying on `find_target_in_args` (currently `dbt source freshness`) could inspect a different warehouse than the one dbt actually built into. Note `-t=<name>` deliberately resolves to the literal target `=<name>`, matching a real quirk of dbt's own `click`-based parsing (short options don't split on `=`) rather than "fixing" it into a disagreement with dbt. Resolved values are also no longer stripped of whitespace, matching click: only a truly empty `DBT_TARGET` is treated as unset.
 
 ## [1.1.1] - 2026-07-06
 

--- a/src/orchestra_dbt/target_finder.py
+++ b/src/orchestra_dbt/target_finder.py
@@ -1,8 +1,25 @@
+import os
+
+
 def find_target_in_args(args: list[str]) -> str | None:
-    if "--target" not in args:
-        return None
-    try:
-        if args[args.index("--target") + 1]:
-            return args[args.index("--target") + 1]
-    except IndexError:
-        return None
+    """Resolve the dbt target this run will use, matching click's real parsing rules.
+
+    `-t` attaches with no `=` splitting (`-tprod` -> `"prod"`, `-t=prod` -> `"=prod"`), a
+    repeated flag resolves to the last occurrence, and values are never stripped -- only a
+    truly empty `DBT_TARGET` counts as unset, not a whitespace-only one.
+    """
+    target: str | None = None
+
+    remaining = iter(args)
+    for arg in remaining:
+        if arg in ("--target", "-t"):
+            target = next(remaining, target)
+        elif arg.startswith("--target="):
+            target = arg.removeprefix("--target=")
+        elif arg.startswith("-t"):
+            target = arg.removeprefix("-t")
+
+    if target is not None:
+        return target
+
+    return os.environ.get("DBT_TARGET") or None

--- a/tests/unit/test_target_finder.py
+++ b/tests/unit/test_target_finder.py
@@ -1,7 +1,19 @@
+import pytest
+
 from src.orchestra_dbt.target_finder import find_target_in_args
 
 
+@pytest.fixture(autouse=True)
+def _no_dbt_target_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DBT_TARGET", raising=False)
+
+
 class TestFindTargetInArgs:
+    """Every case here was checked against real click (`--target`/`-t` is dbt's own option,
+    unmodified), including the two sharp edges: `-t` attaches with no `=` splitting, and a
+    repeated flag resolves to the last occurrence.
+    """
+
     def test_find_target_in_args_success(self):
         args = ["dbt", "source", "freshness", "--target", "test"]
         assert find_target_in_args(args) == "test"
@@ -9,3 +21,79 @@ class TestFindTargetInArgs:
     def test_find_target_in_args_no_target(self):
         args = ["dbt", "source", "freshness"]
         assert find_target_in_args(args) is None
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["dbt", "build", "--target=prod"],
+            ["dbt", "build", "-t", "prod"],
+            ["dbt", "build", "-tprod"],
+            ["dbt", "build", "--target", "prod", "--select", "my_model"],
+            ["dbt", "build", "--select", "my_model", "--target=prod"],
+        ],
+    )
+    def test_all_forms_dbt_accepts(self, args: list[str]) -> None:
+        assert find_target_in_args(args) == "prod"
+
+    def test_short_form_does_not_split_on_equals(self) -> None:
+        """`-t=prod` resolves to the literal target `=prod`, matching click."""
+        assert find_target_in_args(["dbt", "build", "-t=prod"]) == "=prod"
+
+    def test_repeated_flag_resolves_to_the_last_occurrence(self) -> None:
+        assert (
+            find_target_in_args(["dbt", "build", "--target", "dev", "--target", "prod"])
+            == "prod"
+        )
+        assert (
+            find_target_in_args(["dbt", "build", "--target=dev", "--target=prod"])
+            == "prod"
+        )
+
+    def test_falls_back_to_dbt_target_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DBT_TARGET", "from-env")
+        assert find_target_in_args(["dbt", "build"]) == "from-env"
+
+    def test_explicit_flag_beats_the_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DBT_TARGET", "from-env")
+        assert find_target_in_args(["dbt", "build", "--target=prod"]) == "prod"
+
+    def test_trailing_flag_with_no_value_falls_through(self) -> None:
+        assert find_target_in_args(["dbt", "build", "--target"]) is None
+
+    def test_flag_followed_by_another_flag_is_still_consumed_as_the_value(self) -> None:
+        """click consumes the very next token unconditionally, even if it's itself a flag."""
+        assert (
+            find_target_in_args(["dbt", "build", "--target", "--select"]) == "--select"
+        )
+
+    def test_empty_env_var_is_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """click's one special case: an empty (not whitespace) env var means unset."""
+        monkeypatch.setenv("DBT_TARGET", "")
+        assert find_target_in_args(["dbt", "build"]) is None
+
+    def test_whitespace_only_env_var_is_a_literal_target(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unlike an empty string, click passes whitespace through as a real value."""
+        monkeypatch.setenv("DBT_TARGET", "  ")
+        assert find_target_in_args(["dbt", "build"]) == "  "
+
+    def test_cli_values_are_never_stripped(self) -> None:
+        """click passes CLI-supplied values through raw, even empty or whitespace-only."""
+        assert find_target_in_args(["dbt", "build", "--target", ""]) == ""
+        assert find_target_in_args(["dbt", "build", "--target", "  "]) == "  "
+
+    def test_cli_empty_value_does_not_fall_back_to_the_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only an *unset* env var is a fallback trigger -- an explicit empty CLI value is
+        itself the resolved value, exactly as click resolves it.
+        """
+        monkeypatch.setenv("DBT_TARGET", "env-fallback")
+        assert find_target_in_args(["dbt", "build", "--target", ""]) == ""


### PR DESCRIPTION
# Summary

Parses all options for the target argument

## How to test

* Tests
* Run dbt with any of the combinations, i.e. `-t / --target` or env var `DBT_TARGET=y / on / true / 1 / t / yes` and view logs

```bash
uv run pytest
uv run ruff check . && uv run ruff format --check . && uv run basedpyright
```

## Checklist

- [x] Tests added or updated where behaviour changed
- [x] Unit tests and linting pass locally
- [x] Documentation updated where necessary
- [x] Changelog updated for user-visible changes
