### PR TITLE
Add require_explicit_source_freshness toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-08-27
+
+### Added
+
+- `require_explicit_source_freshness` setting (`[tool.orchestra_dbt]` or `ORCHESTRA_REQUIRE_EXPLICIT_SOURCE_FRESHNESS`). When enabled, sources without an explicit `loaded_at_field`/`loaded_at_query` are excluded from state-aware orchestration — no implicit/fallback freshness is inferred for them and models depending on them always run. Useful when implicit freshness is unreliable, e.g. sources defined on views, where warehouse metadata reflects the view rather than the underlying data.
 
 ### Fixed
 
 - `--full-refresh` detection (the switch that disables stateful orchestration for a run) now also recognizes the short flag `-f` and the `DBT_FULL_REFRESH` env var, not just a bare `--full-refresh` token. Previously `orc dbt build -f` or `DBT_FULL_REFRESH=true` triggered a real full refresh in the dbt subprocess while orchestra's own state-aware reuse logic ran as if it hadn't. Env var truthiness matches click's exact recognized states (`1/yes/true/on/t/y` vs `0/no/false/off/f/n/""`), and an explicit flag still wins over the environment.
 - `--target` is now resolved from `--target=<name>`, `-t <name>`, `-tname` and `DBT_TARGET`, not just a bare `--target <name>`. Previously those forms silently fell back to the default target, so anything relying on `find_target_in_args` (currently `dbt source freshness`) could inspect a different warehouse than the one dbt actually built into. Note `-t=<name>` deliberately resolves to the literal target `=<name>`, matching a real quirk of dbt's own `click`-based parsing (short options don't split on `=`) rather than "fixing" it into a disagreement with dbt. Resolved values are also no longer stripped of whitespace, matching click: only a truly empty `DBT_TARGET` is treated as unset.
+
+[1.2.0]: https://github.com/orchestra-hq/sao-paolo/releases/tag/v1.2.0
 
 ## [1.1.1] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Each `[tool.orchestra_dbt]` key can be set in TOML, or omitted and supplied only
 | `local_run` | `ORCHESTRA_LOCAL_RUN` |
 | `debug` | `ORCHESTRA_DBT_DEBUG` |
 | `seed_state_orchestration` | `ORCHESTRA_SEED_STATE_ORCHESTRATION` |
+| `require_explicit_source_freshness` | `ORCHESTRA_REQUIRE_EXPLICIT_SOURCE_FRESHNESS` |
 
 For boolean settings, if the environment variable is **set**, the merged value is `true` only when the value is exactly the string `true` (case-insensitive); otherwise it is `false`. If the variable is **unset**, `pyproject.toml` (or the default) applies.
 
@@ -219,6 +220,7 @@ For boolean settings, if the environment variable is **set**, the merged value i
 | `local_run` | bool | `true` | After reuse, revert patched files (typical for local iteration). |
 | `debug` | bool | `false` | Verbose logging. |
 | `seed_state_orchestration` | bool | `false` | When `true`, seed nodes can be reused from state like models; when `false`, seeds are always treated as dirty for reuse. This feature should be considered experimental and may change in the future. |
+| `require_explicit_source_freshness` | bool | `false` | When `true`, sources without an explicit `loaded_at_field` or `loaded_at_query` are excluded from state-aware orchestration: no implicit/fallback freshness is inferred for them, and models depending on them always run. Use this when implicit freshness is unreliable (for example, sources defined on top of views, where warehouse metadata reflects the view rather than the underlying data). |
 
 ### Resolving multiple backend state configurations
 
@@ -248,6 +250,8 @@ When **both** are omitted, Orchestra can still run **adapter-specific** SQL to i
 | **Other adapters** | varies | No Orchestra fallback unless listed above; use `loaded_at_*` or verify dbt's default behavior for your warehouse. |
 
 For adapters without a registered fallback, if both `loaded_at` settings are missing, Orchestra follows dbt's `FreshnessRunner` behavior (which may surface as warnings or a non-actionable result depending on dbt and the warehouse).
+
+Implicit freshness can be misleading for sources defined on top of **views**: warehouse metadata reports when the view was last altered, not when new data arrived in the underlying tables. To opt out of implicit freshness entirely, set `require_explicit_source_freshness = true` (or `ORCHESTRA_REQUIRE_EXPLICIT_SOURCE_FRESHNESS=true`). Sources without `loaded_at_field`/`loaded_at_query` are then excluded from state-aware orchestration and models depending on them always run; sources with an explicit config keep working as normal.
 
 ### Example snippet
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbt-orchestra"
-version = "1.1.3"
+version = "1.2.0"
 description = "Orchestra wrapper for dbt Core (including state aware orchestration)."
 authors = [{ name = "Orchestra Technologies" }]
 license = "Apache-2.0"

--- a/src/orchestra_dbt/cli.py
+++ b/src/orchestra_dbt/cli.py
@@ -171,7 +171,8 @@ def main(args: tuple[str, ...]) -> None:
 
     try:
         source_freshness: SourceFreshness | None = get_source_freshness(
-            target=find_target_in_args(list(dbt_args))
+            target=find_target_in_args(list(dbt_args)),
+            require_explicit_source_freshness=settings.require_explicit_source_freshness,
         )
     except ImportError as import_error:
         log_error(dbt_core_import_error_message(import_error))

--- a/src/orchestra_dbt/config.py
+++ b/src/orchestra_dbt/config.py
@@ -22,6 +22,7 @@ class OrchestraDbtSettings(BaseModel):
     debug: bool = False
     integration_account_id: str | None = None
     seed_state_orchestration: bool = False
+    require_explicit_source_freshness: bool = False
 
     @field_validator("orchestra_env", mode="before")
     @classmethod
@@ -75,8 +76,12 @@ def _merge_env_overrides(settings: OrchestraDbtSettings) -> OrchestraDbtSettings
 
     seed_state = _env_bool("ORCHESTRA_SEED_STATE_ORCHESTRATION")
     if seed_state is not None:
+        settings = settings.model_copy(update={"seed_state_orchestration": seed_state})
+
+    require_explicit = _env_bool("ORCHESTRA_REQUIRE_EXPLICIT_SOURCE_FRESHNESS")
+    if require_explicit is not None:
         settings = settings.model_copy(
-            update={"seed_state_orchestration": seed_state}
+            update={"require_explicit_source_freshness": require_explicit}
         )
 
     return OrchestraDbtSettings.model_validate(settings.model_dump())

--- a/src/orchestra_dbt/source_freshness/__init__.py
+++ b/src/orchestra_dbt/source_freshness/__init__.py
@@ -94,11 +94,14 @@ def get_source_freshness(
             args.extend(["--target", target])
         dbtRunner().invoke(args=args)
         if sources_without_explicit_freshness:
+            shown = sorted(sources_without_explicit_freshness)[:10]
+            remaining = len(sources_without_explicit_freshness) - len(shown)
             log_warn(
                 f"{len(sources_without_explicit_freshness)} source(s) have no explicit freshness "
                 "config (loaded_at_field or loaded_at_query) and are excluded from state-aware "
                 "orchestration; models depending on them will always run: "
-                + ", ".join(sorted(sources_without_explicit_freshness))
+                + ", ".join(shown)
+                + (f", and {remaining} more" if remaining else "")
             )
         return SourceFreshness(
             sources={

--- a/src/orchestra_dbt/source_freshness/__init__.py
+++ b/src/orchestra_dbt/source_freshness/__init__.py
@@ -11,9 +11,6 @@ from .fallbacks.registry import FALLBACK_BY_ADAPTER_TYPE, loaded_at_fields_unset
 def should_exclude_source(
     compiled_node, require_explicit_source_freshness: bool
 ) -> bool:
-    """A source without an explicit loaded_at_field/loaded_at_query has no reliable
-    freshness signal (e.g. a view's metadata reflects the view, not the underlying
-    data), so it can optionally be excluded from state-aware orchestration."""
     return require_explicit_source_freshness and loaded_at_fields_unset(compiled_node)
 
 
@@ -50,9 +47,6 @@ def get_source_freshness(
             age=0,
         )
 
-    # Sources without an explicit loaded_at_field/loaded_at_query, collected so
-    # they can be excluded from the freshness results when
-    # require_explicit_source_freshness is enabled.
     sources_without_explicit_freshness: set[str] = set()
 
     class OrchestraFreshnessRunner(FreshnessRunner):
@@ -94,14 +88,10 @@ def get_source_freshness(
             args.extend(["--target", target])
         dbtRunner().invoke(args=args)
         if sources_without_explicit_freshness:
-            shown = sorted(sources_without_explicit_freshness)[:10]
-            remaining = len(sources_without_explicit_freshness) - len(shown)
             log_warn(
                 f"{len(sources_without_explicit_freshness)} source(s) have no explicit freshness "
                 "config (loaded_at_field or loaded_at_query) and are excluded from state-aware "
-                "orchestration; models depending on them will always run: "
-                + ", ".join(shown)
-                + (f", and {remaining} more" if remaining else "")
+                "orchestration; models depending on them will always run."
             )
         return SourceFreshness(
             sources={

--- a/src/orchestra_dbt/source_freshness/__init__.py
+++ b/src/orchestra_dbt/source_freshness/__init__.py
@@ -8,7 +8,18 @@ from ..utils import load_json
 from .fallbacks.registry import FALLBACK_BY_ADAPTER_TYPE, loaded_at_fields_unset
 
 
-def get_source_freshness(target: str | None) -> SourceFreshness | None:
+def should_exclude_source(
+    compiled_node, require_explicit_source_freshness: bool
+) -> bool:
+    """A source without an explicit loaded_at_field/loaded_at_query has no reliable
+    freshness signal (e.g. a view's metadata reflects the view, not the underlying
+    data), so it can optionally be excluded from state-aware orchestration."""
+    return require_explicit_source_freshness and loaded_at_fields_unset(compiled_node)
+
+
+def get_source_freshness(
+    target: str | None, require_explicit_source_freshness: bool = False
+) -> SourceFreshness | None:
     try:
         from dbt.artifacts.resources.v1.components import FreshnessThreshold
         from dbt.artifacts.schemas.freshness import SourceDefinition
@@ -39,6 +50,11 @@ def get_source_freshness(target: str | None) -> SourceFreshness | None:
             age=0,
         )
 
+    # Sources without an explicit loaded_at_field/loaded_at_query, collected so
+    # they can be excluded from the freshness results when
+    # require_explicit_source_freshness is enabled.
+    sources_without_explicit_freshness: set[str] = set()
+
     class OrchestraFreshnessRunner(FreshnessRunner):
         def execute(self, compiled_node, manifest) -> FreshnessNodeResult:
             # setting config: freshness: null can impact the execute method
@@ -46,6 +62,10 @@ def get_source_freshness(target: str | None) -> SourceFreshness | None:
             # object.
             if compiled_node.freshness is None:
                 compiled_node.freshness = FreshnessThreshold()
+
+            if should_exclude_source(compiled_node, require_explicit_source_freshness):
+                sources_without_explicit_freshness.add(compiled_node.unique_id)
+                return default_freshness_result(compiled_node)
 
             if loaded_at_fields_unset(compiled_node):
                 handler = FALLBACK_BY_ADAPTER_TYPE.get(self.adapter.type())
@@ -73,10 +93,18 @@ def get_source_freshness(target: str | None) -> SourceFreshness | None:
         if target:
             args.extend(["--target", target])
         dbtRunner().invoke(args=args)
+        if sources_without_explicit_freshness:
+            log_warn(
+                f"{len(sources_without_explicit_freshness)} source(s) have no explicit freshness "
+                "config (loaded_at_field or loaded_at_query) and are excluded from state-aware "
+                "orchestration; models depending on them will always run: "
+                + ", ".join(sorted(sources_without_explicit_freshness))
+            )
         return SourceFreshness(
             sources={
                 source["unique_id"]: source["max_loaded_at"]
                 for source in load_json("target/sources.json")["results"]
+                if source["unique_id"] not in sources_without_explicit_freshness
             }
         )
     except Exception as e:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -41,6 +41,7 @@ def _clear_orchestra_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "ORCHESTRA_DBT_DEBUG",
         "ORCHESTRA_INTEGRATION_ACCOUNT_ID",
         "ORCHESTRA_SEED_STATE_ORCHESTRATION",
+        "ORCHESTRA_REQUIRE_EXPLICIT_SOURCE_FRESHNESS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -157,6 +158,7 @@ def test_load_orchestra_dbt_settings_defaults(
     assert settings.debug is False
     assert settings.integration_account_id is None
     assert settings.seed_state_orchestration is False
+    assert settings.require_explicit_source_freshness is False
 
 
 def test_load_orchestra_dbt_settings_from_pyproject(
@@ -170,6 +172,7 @@ local_run = true
 debug = true
 integration_account_id = "acct-from-toml"
 seed_state_orchestration = true
+require_explicit_source_freshness = true
 """,
         encoding="utf-8",
     )
@@ -183,6 +186,7 @@ seed_state_orchestration = true
     assert settings.debug is True
     assert settings.integration_account_id == "acct-from-toml"
     assert settings.seed_state_orchestration is True
+    assert settings.require_explicit_source_freshness is True
     assert get_integration_account_id() == "acct-from-toml"
 
 
@@ -192,7 +196,8 @@ def test_load_orchestra_dbt_settings_env_overrides_pyproject(
     (tmp_path / "pyproject.toml").write_text(
         '[tool.orchestra_dbt]\nuse_stateful = true\norchestra_env = "stage"\n'
         'integration_account_id = "from-toml"\n'
-        "seed_state_orchestration = false\n",
+        "seed_state_orchestration = false\n"
+        "require_explicit_source_freshness = false\n",
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -200,11 +205,13 @@ def test_load_orchestra_dbt_settings_env_overrides_pyproject(
     monkeypatch.setenv("ORCHESTRA_ENV", "dev")
     monkeypatch.setenv("ORCHESTRA_INTEGRATION_ACCOUNT_ID", "from-env")
     monkeypatch.setenv("ORCHESTRA_SEED_STATE_ORCHESTRATION", "true")
+    monkeypatch.setenv("ORCHESTRA_REQUIRE_EXPLICIT_SOURCE_FRESHNESS", "true")
     settings = load_orchestra_dbt_settings()
     assert settings.use_stateful is False
     assert settings.orchestra_env == "dev"
     assert settings.integration_account_id == "from-env"
     assert settings.seed_state_orchestration is True
+    assert settings.require_explicit_source_freshness is True
 
 
 def test_load_orchestra_dbt_settings_invalid_orchestra_env_in_pyproject(

--- a/tests/unit/test_source_freshness_fallbacks.py
+++ b/tests/unit/test_source_freshness_fallbacks.py
@@ -64,6 +64,24 @@ def test_loaded_at_fields_unset(
     assert loaded_at_fields_unset(node) is expected
 
 
+@pytest.mark.parametrize(
+    ("query", "field", "require_explicit", "expected"),
+    [
+        (None, None, True, True),
+        (None, None, False, False),
+        ("select 1", None, True, False),
+        (None, "updated_at", True, False),
+    ],
+)
+def test_should_exclude_source(
+    query: str | None, field: str | None, require_explicit: bool, expected: bool
+) -> None:
+    from src.orchestra_dbt.source_freshness import should_exclude_source
+
+    node = SimpleNamespace(loaded_at_query=query, loaded_at_field=field)
+    assert should_exclude_source(node, require_explicit) is expected
+
+
 def test_build_source_freshness_result_from_loaded_at_no_freshness_config() -> None:
     pytest.importorskip("dbt.artifacts")
     from dbt.artifacts.schemas.results import FreshnessStatus

--- a/tests/unit/test_source_freshness_fallbacks.py
+++ b/tests/unit/test_source_freshness_fallbacks.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 import pytz
 
+from src.orchestra_dbt.source_freshness import should_exclude_source
 from src.orchestra_dbt.source_freshness.fallbacks.common import (
     build_source_freshness_result_from_loaded_at,
     parse_query_timestamp_cell,
@@ -76,8 +77,6 @@ def test_loaded_at_fields_unset(
 def test_should_exclude_source(
     query: str | None, field: str | None, require_explicit: bool, expected: bool
 ) -> None:
-    from src.orchestra_dbt.source_freshness import should_exclude_source
-
     node = SimpleNamespace(loaded_at_query=query, loaded_at_field=field)
     assert should_exclude_source(node, require_explicit) is expected
 

--- a/uv.lock
+++ b/uv.lock
@@ -483,7 +483,7 @@ wheels = [
 
 [[package]]
 name = "dbt-orchestra"
-version = "1.1.1"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -483,7 +483,7 @@ wheels = [
 
 [[package]]
 name = "dbt-orchestra"
-version = "1.1.3"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Adds a `require_explicit_source_freshness` toggle (`[tool.orchestra_dbt]` in `pyproject.toml`, or `ORCHESTRA_REQUIRE_EXPLICIT_SOURCE_FRESHNESS`), default off.

When enabled, sources without an explicit `loaded_at_field`/`loaded_at_query` are excluded from state-aware orchestration: no implicit/fallback freshness is inferred (the fallback metadata query is skipped), and models depending on them always run. This is an interim mitigation for sources defined on views, where warehouse metadata reflects the view rather than the underlying data.

Also promotes the unreleased changelog entries to 1.2.0 and bumps the version.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ErA13VLE9yHRZEq8EAohT)_